### PR TITLE
Show correct exception on TCPServer init error

### DIFF
--- a/coilmq/server/socketserver.py
+++ b/coilmq/server/socketserver.py
@@ -141,13 +141,13 @@ class StompServer(TCPServer):
         self.log = logging.getLogger('%s.%s' % (self.__module__, self.__class__.__name__))
         if not RequestHandlerClass:
             RequestHandlerClass = StompRequestHandler
-        TCPServer.__init__(self, server_address, RequestHandlerClass)
         self.timeout = timeout
         self.authenticator = authenticator
         self.queue_manager = queue_manager
         self.topic_manager = topic_manager
         self._serving_event = threading.Event()
         self._shutdown_request_event = threading.Event()
+        TCPServer.__init__(self, server_address, RequestHandlerClass)
     
     def server_close(self):
         """


### PR DESCRIPTION
TCPServer.**init** will call server_close method in case of exception.

The current code will hide the exception with another exception caused from the attempt to access to self.queue_manager.

To reproduce it you can try to run:

```
coilmq -p 655354
```

This is the output before the patch:

```
2014-12-18 12:31:45,710 [MainThread] __main__ - ERROR - Stomp server stopped due to error: ThreadedStompServer instance has no attribute 'queue_manager'
2014-12-18 12:31:45,710 [MainThread] __main__ - ERROR - ThreadedStompServer instance has no attribute 'queue_manager'
Traceback (most recent call last):
  File "coilmq/start.py", line 117, in context_serve
    server = server_from_config()
  File "coilmq/start.py", line 82, in server_from_config
    authenticator=authenticator)
  File "/home/lucalanziani/code/coilmq/coilmq/server/socketserver.py", line 144, in __init__
    TCPServer.__init__(self, server_address, RequestHandlerClass)
  File "/usr/lib/python2.7/SocketServer.py", line 423, in __init__
    self.server_close()
  File "/home/lucalanziani/code/coilmq/coilmq/server/socketserver.py", line 158, in server_close
    self.queue_manager.close()
AttributeError: ThreadedStompServer instance has no attribute 'queue_manager'
```

This will be the output after the patch:

```
2014-12-18 12:33:07,514 [MainThread] coilmq.queue.QueueManager - INFO - Shutting down queue manager.
2014-12-18 12:33:07,514 [MainThread] coilmq.topic.TopicManager - INFO - Shutting down topic manager.
2014-12-18 12:33:07,514 [MainThread] __main__ - ERROR - Stomp server stopped due to error: getsockaddrarg: port must be 0-65535.
2014-12-18 12:33:07,514 [MainThread] __main__ - ERROR - getsockaddrarg: port must be 0-65535.
Traceback (most recent call last):
  File "coilmq/start.py", line 117, in context_serve
    server = server_from_config()
  File "coilmq/start.py", line 82, in server_from_config
    authenticator=authenticator)
  File "/home/lucalanziani/code/coilmq/coilmq/server/socketserver.py", line 150, in __init__
    TCPServer.__init__(self, server_address, RequestHandlerClass)
  File "/usr/lib/python2.7/SocketServer.py", line 420, in __init__
    self.server_bind()
  File "/usr/lib/python2.7/SocketServer.py", line 434, in server_bind
    self.socket.bind(self.server_address)
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
OverflowError: getsockaddrarg: port must be 0-65535.
```

Cheers,
Luca
