### PR TITLE
Allowing large messages

### DIFF
--- a/coilmq/util/frames.py
+++ b/coilmq/util/frames.py
@@ -333,7 +333,7 @@ class FrameBuffer(object):
             f = Frame.from_buffer(self._buffer)
             self._pointer = self._buffer.tell()
         except (IncompleteFrame, EmptyBuffer):
-            self._buffer.seek(self._pointer, 0)
+            self._buffer.seek(0, 2)
             return None
 
         return f

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -121,3 +121,28 @@ class BasicTest(BaseFunctionalTestCase):
         res = c1.received_frames.get()
         self.assertEqual(res.cmd, 'message')
         self.assertEqual(res.body, utf8msg)
+
+
+    def test_send_large_message(self):
+        """
+        Test sending a large message after a short one.
+        """
+        c1 = self._new_client()
+        c1.subscribe('/queue/foo')
+
+        shortmessage = 'x'
+        longmessage = 'y' * 1024 * 16
+
+        c2 = self._new_client()
+
+        c2.send('/queue/foo', shortmessage)
+
+        res = c1.received_frames.get()
+        self.assertEqual(res.cmd, 'message')
+        self.assertEqual(res.body, shortmessage)
+
+        c2.send('/queue/foo', longmessage)
+
+        res2 = c1.received_frames.get()
+        self.assertEqual(res2.cmd, 'message')
+        self.assertEqual(res2.body, longmessage)


### PR DESCRIPTION
- when sending a large message after a short one, the pointer of the FrameBuffer would be stuck to the end of the short message, with all the parts of the large message overwriting each other.

Basically I was testing to send some megabytes of data. In server_socketserver.py:74 8192 bytes are read at a time. The FrameBuffer then tries to extract a frame, fails, but doesn't reset the _buffers position to the end, so that the next incoming data is appended, instead of overwriting the first 8192 bytes of the message (or parts thereof).

I just discovered coilmq today, cool project, thx for it. I am not familiar with it, so the above is just a first guess, just m2c.