### PR TITLE
CONNECT without accept-version implies STOMP 1.0

### DIFF
--- a/coilmq/protocol/__init__.py
+++ b/coilmq/protocol/__init__.py
@@ -307,7 +307,7 @@ class STOMP11(STOMP10):
             raise ProtocolError("No subscription specified for NACK command.")
 
     def _negotiate_protocol(self, frame, response):
-        client_versions = frame.headers.get('accept-version')
+        client_versions = frame.headers.get('accept-version', '1.0')
         if not client_versions:
             raise ProtocolError('No version specified')
         common = set(client_versions.split(',')) & self.SUPPORTED_VERSIONS


### PR DESCRIPTION
The STOMP specification says that a `CONNECT` frame without an `accept-version` header means the client only supports STOMP 1.0.  (See https://stomp.github.io/stomp-specification-1.1.html#Protocol_Negotiation.)  This change results in the server accepting connections from clients who send `CONNECT` frames without an `accept-version` header and communicating with those clients using STOMP 1.0.

The existing behavior is totally valid given that the STOMP 1.1 and 1.2 specifications both say, "The server can reject any connection attempt. The server SHOULD respond back with an ERROR frame listing why the connection was rejected and then close the connection."  That said, I think it would be nicer to accept connections from clients that intentionally don't provide an `accept-version` header.

See hozn/coilmq#29