### PR TITLE
Client subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.py[cod]
+__pycache__/
+
+*.egg-info/
+.eggs/
+
+.*
+/data

--- a/coilmq/protocol/__init__.py
+++ b/coilmq/protocol/__init__.py
@@ -170,10 +170,11 @@ class STOMP10(STOMP):
         if not dest:
             raise ProtocolError('Missing destination for SUBSCRIBE command.')
 
+        id = frame.headers.get('id')
         if dest.startswith('/queue/'):
-            self.engine.queue_manager.subscribe(self.engine.connection, dest)
+            self.engine.queue_manager.subscribe(self.engine.connection, dest, id=id)
         else:
-            self.engine.topic_manager.subscribe(self.engine.connection, dest)
+            self.engine.topic_manager.subscribe(self.engine.connection, dest, id=id)
 
     def unsubscribe(self, frame):
         """
@@ -183,10 +184,11 @@ class STOMP10(STOMP):
         if not dest:
             raise ProtocolError('Missing destination for UNSUBSCRIBE command.')
 
+        id = frame.headers.get('id')
         if dest.startswith('/queue/'):
-            self.engine.queue_manager.unsubscribe(self.engine.connection, dest)
+            self.engine.queue_manager.unsubscribe(self.engine.connection, dest, id=id)
         else:
-            self.engine.topic_manager.unsubscribe(self.engine.connection, dest)
+            self.engine.topic_manager.unsubscribe(self.engine.connection, dest, id=id)
 
     def begin(self, frame):
         """
@@ -235,7 +237,7 @@ class STOMP10(STOMP):
         """
         if not frame.message_id:
             raise ProtocolError("No message-id specified for ACK command.")
-        self.engine.queue_manager.ack(self.engine.connection, frame)
+        self.engine.queue_manager.ack(self.engine.connection, frame, id=frame.headers.get("id"))
 
     def disconnect(self, frame):
         """
@@ -325,6 +327,23 @@ class STOMP11(STOMP10):
                 self.engine.protocol = protocol_class(self.engine)
                 self.engine.protocol.connect(frame, response=response)
 
+    def subscribe(self, frame):
+        if "id" not in frame.headers:
+            raise ProtocolError("No 'id' specified for SUBSCRIBE command.")
+        super().subscribe(frame)
+
+    def unsubscribe(self, frame):
+        if "id" not in frame.headers:
+            raise ProtocolError("No 'id' specified for UNSUBSCRIBE command.")
+        super().unsubscribe(frame)
+
+    def ack(self, frame):
+        if "subscription" not in frame.headers:
+            raise ProtocolError("No 'subscription' specified for ACK command.")
+        if "message-id" not in frame.headers:
+            raise ProtocolError("No message-id specified for ACK command.")
+        self.engine.queue_manager.ack(self.engine.connection, frame, id=frame.headers["subscription"])
+
 
 class STOMP12(STOMP11):
 
@@ -337,6 +356,13 @@ class STOMP12(STOMP11):
         if host != socket.getfqdn():
             raise ProtocolError('Virtual hosting is not supported or host is unknown')
         super(STOMP12, self).connect(frame, response)
+
+    def ack(self, frame):
+        if "id" not in frame.headers:
+            raise ProtocolError("No 'id' specified for ACK command.")
+        if "message-id" not in frame.headers:
+            raise ProtocolError("No message-id specified for ACK command.")
+        self.engine.queue_manager.ack(self.engine.connection, frame, id=frame.headers["id"])
 
 
 PROTOCOL_MAP = {'1.0': STOMP10, '1.1': STOMP11, '1.2': STOMP12}

--- a/coilmq/protocol/__init__.py
+++ b/coilmq/protocol/__init__.py
@@ -235,7 +235,7 @@ class STOMP10(STOMP):
         """
         Handles the ACK command: Acknowledges receipt of a message.
         """
-        if not frame.message_id:
+        if "message-id" not in frame.headers:
             raise ProtocolError("No message-id specified for ACK command.")
         self.engine.queue_manager.ack(self.engine.connection, frame, id=frame.headers.get("id"))
 

--- a/coilmq/queue.py
+++ b/coilmq/queue.py
@@ -128,7 +128,7 @@ class QueueManager(object):
         return self._subscriptions.subscriber_count(destination=destination)
 
     @synchronized(lock)
-    def subscribe(self, connection, destination):
+    def subscribe(self, connection, destination, id=None):
         """
         Subscribes a connection to the specified destination (topic or queue). 
 
@@ -139,11 +139,11 @@ class QueueManager(object):
         @type destination: C{str} 
         """
         self.log.debug("Subscribing %s to %s" % (connection, destination))
-        subscription = self._subscriptions.subscribe(connection, destination)
+        subscription = self._subscriptions.subscribe(connection, destination, id=id)
         self._send_backlog(subscription, destination)
 
     @synchronized(lock)
-    def unsubscribe(self, connection, destination):
+    def unsubscribe(self, connection, destination, id=None):
         """
         Unsubscribes a connection from a destination (topic or queue).
 
@@ -154,7 +154,7 @@ class QueueManager(object):
         @type destination: C{str} 
         """
         self.log.debug("Unsubscribing %s from %s" % (connection, destination))
-        self._subscriptions.unsubscribe(connection, destination)
+        self._subscriptions.unsubscribe(connection, destination, id=id)
 
     @synchronized(lock)
     def disconnect(self, connection):
@@ -209,7 +209,7 @@ class QueueManager(object):
             self._send_frame(selected, message)
 
     @synchronized(lock)
-    def ack(self, connection, frame, transaction=None):
+    def ack(self, connection, frame, transaction=None, id=None):
         """
         Acknowledge receipt of a message.
 
@@ -225,7 +225,7 @@ class QueueManager(object):
         """
         self.log.debug("ACK %s for %s" % (frame, connection))
 
-        subscription = Subscription.from_frame(frame, connection)
+        subscription = Subscription.factory(connection=connection, id=id)
         pending_frame = self._pending.get(subscription, None)
 
         if pending_frame is not None:

--- a/coilmq/queue.py
+++ b/coilmq/queue.py
@@ -231,9 +231,10 @@ class QueueManager(object):
         if pending_frame is not None:
             # Make sure that the frame being acknowledged matches
             # the expected frame
-            if pending_frame.headers.get('message-id') != frame.headers.get('message-id'):
+            message_id = frame.headers.get('message-id')
+            if pending_frame.headers.get('message-id') != message_id:
                 self.log.warning(
-                    "Got a ACK for unexpected message-id: %s" % frame.message_id)
+                    "Got a ACK for unexpected message-id: %s", message_id)
                 self.store.requeue(pending_frame.destination, pending_frame)
                 # (The pending frame will be removed further down)
 

--- a/coilmq/queue.py
+++ b/coilmq/queue.py
@@ -354,6 +354,9 @@ class QueueManager(object):
         assert subscription is not None
         assert frame is not None
 
+        if frame.cmd == "message":
+            frame.headers["subscription"] = subscription.id
+
         self.log.debug("Delivering frame %s to subscription %s" %
                        (frame, subscription))
 

--- a/coilmq/scheduler.py
+++ b/coilmq/scheduler.py
@@ -35,13 +35,13 @@ class SubscriberPriorityScheduler(object):
         Chooses which subscriber (from list) should recieve specified message.
 
         @param subscribers: Collection of subscribed connections eligible to receive message. 
-        @type subscribers: C{list} of L{coilmq.server.StompConnection}
+        @type subscribers: C{list} of L{coilmq.subscription.Subscription}
 
         @param message: The message to be delivered. 
         @type message: L{stompclient.frame.Frame}
 
         @return: A selected subscriber from the list or None if no subscriber could be chosen (e.g. list is empty).
-        @rtype: L{coilmq.server.StompConnection}
+        @rtype: L{coilmq.subscription.Subscription}
         """
 
 
@@ -75,13 +75,13 @@ class RandomSubscriberScheduler(SubscriberPriorityScheduler):
         Chooses a random connection from subscribers to deliver specified message.
 
         @param subscribers: Collection of subscribed connections to destination. 
-        @type subscribers: C{list} of L{coilmq.server.StompConnection}
+        @type subscribers: C{list} of L{coilmq.subscription.Subscription}
 
         @param message: The message to be delivered. 
         @type message: L{stompclient.frame.Frame}
 
         @return: A random subscriber from the list or None if list is empty.
-        @rtype: L{coilmq.server.StompConnection}
+        @rtype: L{coilmq.subscription.Subscription}
         """
         if not subscribers:
             return None
@@ -99,18 +99,18 @@ class FavorReliableSubscriberScheduler(SubscriberPriorityScheduler):
         subscriber pool to deliver specified message.
 
         @param subscribers: Collection of subscribed connections to destination. 
-        @type subscribers: C{list} of L{coilmq.server.StompConnection}
+        @type subscribers: C{list} of L{coilmq.subscription.Subscription}
 
         @param message: The message to be delivered. 
         @type message: L{stompclient.frame.Frame}
 
         @return: A random subscriber from the list or None if list is empty.
-        @rtype: L{coilmq.server.StompConnection}
+        @rtype: L{coilmq.subscription.Subscription}
         """
         if not subscribers:
             return None
         reliable_subscribers = [
-            s for s in subscribers if s.reliable_subscriber]
+            s for s in subscribers if s.connection.reliable_subscriber]
         if reliable_subscribers:
             return random.choice(reliable_subscribers)
         else:

--- a/coilmq/subscription.py
+++ b/coilmq/subscription.py
@@ -1,0 +1,139 @@
+import itertools
+from dataclasses import dataclass
+from collections import defaultdict
+from typing import Any
+from coilmq.server import StompConnection
+
+DEFAULT_SUBSCRIPTION_ID = 0
+
+
+@dataclass(frozen=True)
+class Subscription:
+    connection: StompConnection
+    id: Any
+
+    @classmethod
+    def from_frame(cls, frame, connection):
+        """
+        @param frame: STOMP frame.
+        @type frame: L{coilmq.util.frames.Frame}
+
+        @param connection: The connection to subscribe.
+        @type connection: L{coilmq.server.StompConnection}
+
+        @return: The subscription.
+        @rtype: C{Subscription}
+        """
+        id = frame.headers.get("id", DEFAULT_SUBSCRIPTION_ID)
+        return cls(connection=connection, id=id)
+
+
+class SubscriptionManager:
+    def __init__(self):
+        """
+        @ivar _subscriptions: A dict of registered subscriptions, keyed by destination.
+        @type _subscriptions: C{dict} of C{str} to C{set} of L{coilmq.subscription.Subscription}
+        """
+        self._subscriptions = defaultdict(set)
+
+    def subscribe(self, connection, destination, id=None):
+        """
+        Subscribes a connection to the specified destination.
+
+        @param destination: The destination (e.g. '/queue/foo')
+        @type destination: C{str}
+
+        @param connection: The connection to subscribe.
+        @type connection: L{coilmq.server.StompConnection}
+
+        @param id: subscription identifier (optional)
+        @type id: C{int}
+
+        @return: The subscription.
+        @rtype: C{Subscription}
+        """
+        if id is None:
+            id = DEFAULT_SUBSCRIPTION_ID
+        subscription = Subscription(connection=connection, id=id)
+        self._subscriptions[destination].add(subscription)
+        return subscription
+
+    def unsubscribe(self, connection, destination, id=None):
+        """
+        Unsubscribes a connection from a destination.
+
+        @param connection: The client connection to unsubscribe.
+        @type connection: L{coilmq.server.StompConnection}
+
+        @param destination: The topic/queue destination (e.g. '/queue/foo')
+        @type destination: C{str}
+
+        @param id: subscription identifier (optional)
+        @type id: C{int}
+        """
+        subscriptions = self._subscriptions.get(destination, None)
+        if subscriptions is None:
+            return
+        if id is None:
+            id = DEFAULT_SUBSCRIPTION_ID
+        subscription = Subscription(connection=connection, id=id)
+        try:
+            subscriptions.remove(subscription)
+        except KeyError:
+            pass
+        if not subscriptions:
+            del self._subscriptions[destination]
+
+    def disconnect(self, connection):
+        """
+        Removes a client connection.
+
+        @param connection: The client connection to unsubscribe.
+        @type connection: L{coilmq.server.StompConnection}
+        """
+        for destination, subscriptions in list(self._subscriptions.items()):
+            subscriptions = {
+                subscription
+                for subscription in subscriptions
+                if subscription.connection != connection
+            }
+            if subscriptions:
+                self._subscriptions[destination] = subscriptions
+            else:
+                del self._subscriptions[destination]
+
+    def subscriber_count(self, destination=None):
+        """
+        Returns a count of the number of subscribers.
+
+        If destination is specified then it only returns count of subscribers
+        for that specific destination.
+
+        @param destination: The optional topic/queue destination (e.g. '/queue/foo')
+        @type destination: C{str}
+
+        @return: The number of subscribers.
+        @rtype: C{int}
+        """
+        if destination:
+            return len(self._subscriptions.get(destination, set()))
+        else:
+            return sum(map(len, self._subscriptions.values()))
+
+    def subscribers(self, destination):
+        """
+        Returns subscribers to a single destination.
+
+        @param destination: The optional topic/queue destination (e.g. '/queue/foo')
+        @type destination: C{str}
+
+        @return: The subscribers.
+        @rtype: C{set}
+        """
+        return self._subscriptions.get(destination, set())
+
+    def all_subscribers(self):
+        """
+        Yields all subscribers.
+        """
+        yield from itertools.chain(self._subscriptions.items())

--- a/coilmq/subscription.py
+++ b/coilmq/subscription.py
@@ -13,7 +13,7 @@ class Subscription:
     id: Any
 
     @classmethod
-    def from_frame(cls, frame, connection):
+    def factory(cls, connection, id=None):
         """
         @param frame: STOMP frame.
         @type frame: L{coilmq.util.frames.Frame}
@@ -21,10 +21,14 @@ class Subscription:
         @param connection: The connection to subscribe.
         @type connection: L{coilmq.server.StompConnection}
 
+        @param id: The subscription identifier (introduced in STOMP 1.1).
+        @type id: C{Any}
+
         @return: The subscription.
         @rtype: C{Subscription}
         """
-        id = frame.headers.get("id", DEFAULT_SUBSCRIPTION_ID)
+        if id is None:
+            id = DEFAULT_SUBSCRIPTION_ID
         return cls(connection=connection, id=id)
 
 

--- a/coilmq/topic.py
+++ b/coilmq/topic.py
@@ -7,6 +7,7 @@ Patrick Hurley and Lionel Bouton.  See http://stompserver.rubyforge.org/
 import logging
 import threading
 import uuid
+from copy import deepcopy
 from coilmq.subscription import SubscriptionManager
 from coilmq.util.concurrency import synchronized
 
@@ -121,8 +122,10 @@ class TopicManager(object):
 
         bad_subscribers = set()
         for subscriber in self._subscriptions.subscribers(dest):
+            frame = deepcopy(message)
+            frame.headers["subscription"] = subscriber.id
             try:
-                subscriber.connection.send_frame(message)
+                subscriber.connection.send_frame(frame)
             except:
                 self.log.exception(
                     "Error delivering message to subscriber %s; client will be disconnected." % subscriber)

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -33,6 +33,13 @@ class MockConnection(object):
         self.frames = []
 
 
+class MockSubscription(object):
+
+    def __init__(self):
+        self.id = 0
+        self.connection = MockConnection()
+
+
 class MockAuthenticator(auth.Authenticator):
     LOGIN = 'foo'
     PASSCODE = 'bar'

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -77,7 +77,7 @@ class MockQueueManager(object):
         if transaction:
             self.transaction_frames[connection][transaction].append(frame)
 
-        self.acks.append(frame.message_id)
+        self.acks.append(frame.headers.get("message-id"))
 
     def resend_transaction_frames(self, connection, transaction):
         """ Resend the messages that were ACK'd in specified transaction.

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -62,10 +62,10 @@ class MockQueueManager(object):
     def disconnect(self, connection):
         pass
 
-    def subscribe(self, conn, dest):
+    def subscribe(self, conn, dest, id=None):
         self.queues[dest].add(conn)
 
-    def unsubscribe(self, conn, dest):
+    def unsubscribe(self, conn, dest, id=None):
         if dest in self.queues:
             self.queues[dest].remove(conn)
 
@@ -115,10 +115,10 @@ class MockTopicManager(object):
         self.topics = defaultdict(set)
         self.messages = []
 
-    def subscribe(self, conn, dest):
+    def subscribe(self, conn, dest, id=None):
         self.topics[dest].add(conn)
 
-    def unsubscribe(self, conn, dest):
+    def unsubscribe(self, conn, dest, id=None):
         if dest in self.topics:
             self.topics[dest].remove(conn)
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -285,7 +285,8 @@ class QueueManagerTest(unittest.TestCase):
         self.qm.resend_transaction_frames(conn1, transaction='abc')
 
         self.assertEqual(len(conn1.frames), 3, "Expected 3 frames after re-transmit.")
-        self.assertTrue(self.qm._pending[conn1], "Expected 1 pending (waiting on ACK) frame.""")
+        pending = {s for s in self.qm._pending if s.connection == conn1}
+        self.assertEqual(len(pending), 1, "Expected 1 pending (waiting on ACK) frame.""")
 
     def test_disconnect_pending_frames(self):
         """ Test a queue disconnect when there are pending frames. """

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -142,6 +142,8 @@ class QueueManagerTest(unittest.TestCase):
         self.qm.subscribe(self.conn, dest)
 
         self.assertEqual(len(self.conn.frames), 1, "Expected frame to be delivered")
+        subscription = self.conn.frames[0].headers.pop("subscription", None)
+        self.assertEqual(subscription, 0)
         self.assertEqual(self.conn.frames[0], f)
 
     def test_send_backlog_err_unreliable(self):
@@ -174,6 +176,10 @@ class QueueManagerTest(unittest.TestCase):
         self.qm.subscribe(self.conn, dest)
 
         self.assertEqual(len(self.conn.frames), 2, "Expected frame to be delivered")
+        for frame in self.conn.frames:
+            subscription = frame.headers.pop("subscription", None)
+            self.assertEqual(subscription, 0)
+
         self.assertListEqual(list(self.conn.frames), [f2, f])
 
     def test_send_reliableFirst(self):
@@ -246,6 +252,8 @@ class QueueManagerTest(unittest.TestCase):
         self.qm.ack(conn1, ack)
 
         self.assertEqual(len(conn1.frames), 2, "Expected 2 frames now, after ACK.")
+        subscription = conn1.frames[1].headers.pop("subscription", None)
+        self.assertEqual(subscription, 0)
         self.assertEqual(conn1.frames[1], m2)
 
     def test_ack_transaction(self):
@@ -280,6 +288,8 @@ class QueueManagerTest(unittest.TestCase):
         self.qm.ack(conn1, ack, transaction='abc')
 
         self.assertEqual(len(conn1.frames), 2, "Expected 2 frames now, after ACK.")
+        subscription = conn1.frames[1].headers.pop("subscription", None)
+        self.assertEqual(subscription, 0)
         self.assertEqual(conn1.frames[1],  m2)
 
         self.qm.resend_transaction_frames(conn1, transaction='abc')

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,7 +4,7 @@ Tests for the scheduler implementation.
 import unittest
 
 from coilmq.scheduler import FavorReliableSubscriberScheduler
-from tests.mock import MockConnection
+from tests.mock import MockSubscription
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
@@ -29,13 +29,13 @@ class QueueDeliverySchedulerTest(unittest.TestCase):
 
         sched = FavorReliableSubscriberScheduler()
 
-        conn1 = MockConnection()
-        conn1.reliable_subscriber = True
+        sub1 = MockSubscription()
+        sub1.connection.reliable_subscriber = True
 
-        conn2 = MockConnection()
-        conn2.reliable_subscriber = False
+        sub2 = MockSubscription()
+        sub2.connection.reliable_subscriber = False
 
-        choice = sched.choice((conn1, conn2), None)
+        choice = sched.choice((sub1, sub2), None)
 
         self.assertIs(
-            choice, conn1, "Expected reliable connection to be selected.")
+            choice, sub1, "Expected reliable connection to be selected.")

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,0 +1,41 @@
+"""
+Tests for the subscription management.
+"""
+import unittest
+
+from coilmq.subscription import SubscriptionManager
+from tests.mock import MockConnection
+
+
+class SubscriptionManagerTest(unittest.TestCase):
+    """Tests for the subscription manager."""
+
+    def test_subscribing(self):
+        """Test (un)subscribing."""
+
+        subscriptions = SubscriptionManager()
+        conn1 = MockConnection()
+        conn2 = MockConnection()
+
+        for _ in range(2):
+            subscriptions.subscribe(conn1, "dest1", id=1)
+            subscriptions.subscribe(conn1, "dest1", id=2)
+            subscriptions.subscribe(conn2, "dest1", id=1)
+            subscriptions.subscribe(conn1, "dest2", id=1)
+            subscriptions.subscribe(conn1, "dest2", id=2)
+            subscriptions.subscribe(conn2, "dest2", id=1)
+
+        self.assertEqual(subscriptions.subscriber_count("dest1"), 3)
+        self.assertEqual(subscriptions.subscriber_count("dest2"), 3)
+        self.assertEqual(subscriptions.subscriber_count(), 6)
+
+        subscriptions.unsubscribe(conn1, "dest2", id=2)
+
+        self.assertEqual(subscriptions.subscriber_count("dest1"), 3)
+        self.assertEqual(subscriptions.subscriber_count("dest2"), 2)
+        self.assertEqual(subscriptions.subscriber_count(), 5)
+
+        subscriptions.disconnect(conn2)
+        self.assertEqual(subscriptions.subscriber_count("dest1"), 2)
+        self.assertEqual(subscriptions.subscriber_count("dest2"), 1)
+        self.assertEqual(subscriptions.subscriber_count(), 3)

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -99,4 +99,5 @@ class TopicManagerTest(unittest.TestCase):
 
         # Make sure our bad client got disconnected
         # (This might be a bit too intimate.)
-        self.assertNotIn(bad_client, self.tm._topics[dest])
+        connections = {s.connection for s in self.tm._subscriptions.subscribers(dest)}
+        self.assertNotIn(bad_client, connections)

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -40,6 +40,8 @@ class TopicManagerTest(unittest.TestCase):
         self.tm.send(f)
 
         self.assertEqual(len(self.conn.frames), 1)
+        subscription = self.conn.frames[0].headers.pop("subscription", None)
+        self.assertEqual(subscription, 0)
         self.assertEqual(self.conn.frames[0], f)
 
     def test_unsubscribe(self):
@@ -51,6 +53,8 @@ class TopicManagerTest(unittest.TestCase):
         self.tm.send(f)
 
         self.assertEqual(len(self.conn.frames), 1)
+        subscription = self.conn.frames[0].headers.pop("subscription", None)
+        self.assertEqual(subscription, 0)
         self.assertEqual(self.conn.frames[0], f)
 
         self.tm.unsubscribe(self.conn, dest)
@@ -95,6 +99,8 @@ class TopicManagerTest(unittest.TestCase):
 
         # Make sure out good client got the message.
         self.assertEqual(len(self.conn.frames), 1)
+        subscription = self.conn.frames[0].headers.pop("subscription", None)
+        self.assertEqual(subscription, 0)
         self.assertEqual(self.conn.frames[0], f)
 
         # Make sure our bad client got disconnected


### PR DESCRIPTION
Closes  #25

* Server-side management of subscriptions (connection + id) instead of connections
* For STOMP >= 1.1: make subscription id mandatory for client frames SUBSCRIBE, UNSUBSCRIBE and ACK
* Add client subscription id for server frame MESSAGE
* Bug: `message_id` is not a frame attribute but a header key `message-id`