### PR TITLE
Fix heartbeats

### DIFF
--- a/coilmq/engine.py
+++ b/coilmq/engine.py
@@ -92,3 +92,4 @@ class StompEngine(object):
         self.connected = False
         self.queue_manager.disconnect(self.connection)
         self.topic_manager.disconnect(self.connection)
+        self.protocol.disable_heartbeat()

--- a/coilmq/server/socket_server.py
+++ b/coilmq/server/socket_server.py
@@ -78,6 +78,9 @@ class StompRequestHandler(BaseRequestHandler, StompConnection):
                         self.log.debug("RECV: %r" % data)
                     self.buffer.append(data)
 
+                    if not self.buffer.buffer_empty():
+                        self.engine.protocol.process_heartbeat()
+
                     for frame in self.buffer:
                         self.log.debug("Processing frame: %s" % frame)
                         self.engine.process_frame(frame)
@@ -111,6 +114,15 @@ class StompRequestHandler(BaseRequestHandler, StompConnection):
         if self.debug:  # pragma: no cover
             self.log.debug("SEND: %r" % packed)
         self.request.sendall(packed)
+
+    def send_heartbeat(self):
+        """ Sends an EOL to connected socket client.
+
+        """
+        heartbeat = b'\n'
+        if self.debug:  # pragma: no cover
+            self.log.debug("SEND: %r" % heartbeat)
+        self.request.sendall(heartbeat)
 
 
 class StompServer(TCPServer):

--- a/coilmq/util/frames.py
+++ b/coilmq/util/frames.py
@@ -43,6 +43,7 @@ def parse_headers(buff):
     """
     Parses buffer and returns command and headers as strings
     """
+
     preamble_lines = list(map(
         lambda x: six.u(x).decode(),
         iter(lambda: buff.readline().strip(), b''))
@@ -235,7 +236,7 @@ class FrameBuffer(object):
     may provide multiple frames in one data buffer).
 
     @ivar _buffer: The internal byte buffer.
-    @type _buffer: C{str}
+    @type _buffer: C{io.BytesIO}
 
     @ivar debug: Log extra parsing debug (logs will be DEBUG level).
     @type debug: C{bool}
@@ -265,7 +266,7 @@ class FrameBuffer(object):
         """
         Clears (empties) the internal buffer.
         """
-        self._buffer = io
+        self._buffer = io.BytesIO()
 
     def buffer_len(self):
         """
@@ -286,7 +287,7 @@ class FrameBuffer(object):
         Appends bytes to the internal buffer (may or may not contain full stomp frames).
 
         @param data: The bytes to append.
-        @type data: C{str}
+        @type data: C{bytes}
         """
         self._buffer.write(data)
 

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -24,6 +24,7 @@ class MockConnection(object):
 
     def __init__(self):
         self.frames = []
+        self.heartbeat_count = 0
         self.reliable_subscriber = False
 
     def send_frame(self, frame):
@@ -31,6 +32,10 @@ class MockConnection(object):
 
     def reset(self):
         self.frames = []
+        self.heartbeat_count = 0
+
+    def send_heartbeat(self):
+        self.heartbeat_count += 1
 
 
 class MockSubscription(object):

--- a/tests/protocol/test_1_1.py
+++ b/tests/protocol/test_1_1.py
@@ -25,8 +25,7 @@ class STOMP11TestCase(ProtocolBaseTestCase):
         with self.with_heartbeat(self.engine.protocol):
             self.engine.process_frame(Frame(frames.CONNECT, headers={'heart-beat': '0,100', 'accept-version': '1.1'}))
             time.sleep(0.53)
-            heartbeats = [frame for frame in self.conn.frames if frame.headers.get('message') == 'heartbeat']
-            self.assertAlmostEqual(len(heartbeats), 5, delta=1)
+            self.assertAlmostEqual(self.conn.heartbeat_count, 5, delta=1)
 
     def test_no_heartbeat_from_client(self):
         with self.with_heartbeat(STOMP11(self.engine, receive_heartbeat_interval=50)):


### PR DESCRIPTION
I had the need for a python STOMP implementation and this looked to be a great start. 
Heartbeats were not working correctly so I have implemented a fix, please take a look and see what you think.

Issues were:
  heartbeat timers continued after engine was disconnected
  any message received via the socket should be considered the last communication
  allow some flex in the last heartbeat received before closing the connection (perhaps I have flexed this too much at 2*interval)