### PR TITLE
remove pkg_resources from coilmq package

### DIFF
--- a/coilmq/config/__init__.py
+++ b/coilmq/config/__init__.py
@@ -23,7 +23,6 @@ except ImportError:
     from ConfigParser import ConfigParser
 
 
-from pkg_resources import resource_filename, resource_stream
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/news.txt
+++ b/docs/news.txt
@@ -3,6 +3,16 @@ News: CoilMQ
 
 .. contents::
 
+Unreleased
+----------
+* Removed uses of `pkg_resources` (issue 39)
+
+1.0.1
+-----
+
+1.0.0
+-----
+
 0.6.1
 -----
 * Error with one subscriber causes topic messages not to be delivered to 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --doctest-modules --ignore=setup.py --cov=coilmq --cov=tests
+python_files = *.py

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,4 @@ mock
 pytest
 pytest-cov
 dataclasses
+importlib_resources; python_version < "3.9"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,4 @@ mock
 pytest
 pytest-cov
 dataclasses
+setuptools<82

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-SQLAlchemy
+SQLAlchemy<2
 fakeredis
 mock
 pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,3 @@ mock
 pytest
 pytest-cov
 dataclasses
-setuptools<82

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@
 
 [easy_install]
 zip_ok=False
-
-[pytest]
-python_files = *.py

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from StringIO import StringIO
 
-from pkg_resources import resource_stream, resource_filename
+from pkg_resources import resource_filename
 
 from coilmq.auth.simple import SimpleAuthenticator
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -61,11 +61,9 @@ class SimpleAuthenticatorTest(unittest.TestCase):
         Test loading store from file-like object.
         """
         auth = SimpleAuthenticator()
-        with (
-            as_file(files('tests.resources').joinpath('auth.ini')) as filename,
-            filename.open() as fp,
-        ):
-            auth.from_configfile(fp)
+        with as_file(files('tests.resources').joinpath('auth.ini')) as filename:
+            with filename.open() as fp:
+                auth.from_configfile(fp)
 
         assert auth.authenticate('juniper', 'b3rr1es') == True
         assert auth.authenticate('oak', 'ac$rrubrum') == True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,7 +8,10 @@ try:
     unicode = str
 except ImportError:
     from StringIO import StringIO
-from importlib.resources import as_file, files
+try:
+    from importlib.resources import as_file, files
+except ImportError:
+    from importlib_resources import as_file, files
 
 from coilmq.auth.simple import SimpleAuthenticator
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,8 +8,7 @@ try:
     unicode = str
 except ImportError:
     from StringIO import StringIO
-
-from pkg_resources import resource_filename
+from importlib.resources import as_file, files
 
 from coilmq.auth.simple import SimpleAuthenticator
 
@@ -49,9 +48,9 @@ class SimpleAuthenticatorTest(unittest.TestCase):
         """
         Test the loading store from config file path.
         """
-        filename = resource_filename('tests.resources', 'auth.ini')
         auth = SimpleAuthenticator()
-        auth.from_configfile(filename)
+        with as_file(files('tests.resources').joinpath('auth.ini')) as filename:
+            auth.from_configfile(filename)
         assert auth.authenticate('juniper', 'b3rr1es') == True
         assert auth.authenticate('oak', 'ac$rrubrum') == True
         assert auth.authenticate('pinetree', 'str0bus') == True
@@ -61,8 +60,11 @@ class SimpleAuthenticatorTest(unittest.TestCase):
         """
         Test loading store from file-like object.
         """
-        with open(resource_filename('tests.resources', 'auth.ini'), 'r') as fp:
-            auth = SimpleAuthenticator()
+        auth = SimpleAuthenticator()
+        with (
+            as_file(files('tests.resources').joinpath('auth.ini')) as filename,
+            filename.open() as fp,
+        ):
             auth.from_configfile(fp)
 
         assert auth.authenticate('juniper', 'b3rr1es') == True
@@ -74,13 +76,13 @@ class SimpleAuthenticatorTest(unittest.TestCase):
         """
         Test loading store with invalid file path.
         """
-        filename = resource_filename('tests.resources', 'auth-invlaid.ini')
         auth = SimpleAuthenticator()
-        try:
-            auth.from_configfile(filename)
-            self.fail("Expected error with invalid filename.")
-        except ValueError as e:
-            pass
+        with as_file(files('tests.resources').joinpath('auth-invlaid.ini')) as filename:
+            try:
+                auth.from_configfile(filename)
+                self.fail("Expected error with invalid filename.")
+            except ValueError as e:
+                pass
 
     def test_from_configfile_fp_invalid(self):
         """


### PR DESCRIPTION
Fixes #39 

The PR includes the following changes:
1. remove `pkg_resources` import in `coilmq.config` module; the imported functions were not actually used
2. replace `pkg_resources.resource_filename` in `tests/test_auth.py` with `importlib.resources.{as_file,files}`
3. pin `SQLAlchemy` to <2 in `requirements/test.txt`; the tests were written to the pre-SQLAlchemy 2 API
4. add `importlib_resources` to `requirements/test.txt` for Python < 3.9; `importlib.resources` lacks `as_file` and `files` in versions prior to Python 3.9
5. move the `python_files` setting from `setup.cfg` to `pytest.ini;` newer pytest versions don't support having a `[pytest]` section in `setup.cfg`

I tested these changes under Python 3.14.2 like so:

```shell
uv venv
uv pip install --editable .
uv pip install -r requirements/test.txt
uv run pytest
```