### PR TITLE
fix "sending large messages leads to corrupted FrameBuffer and stuck server"

### DIFF
--- a/coilmq/util/frames.py
+++ b/coilmq/util/frames.py
@@ -319,7 +319,9 @@ class FrameBuffer:
             f = Frame.from_buffer(self._buffer)
             self._pointer = self._buffer.tell()
         except (IncompleteFrame, EmptyBuffer):
-            self._buffer.seek(self._pointer, 0)
+            # Seek to the end of the buffer so the next call to
+            # `append()` does not overwrite part of the frame.
+            self._buffer.seek(0, 2)
             return None
 
         return f

--- a/docs/news.txt
+++ b/docs/news.txt
@@ -7,6 +7,11 @@ Unreleased
 ----------
 * Removed uses of `pkg_resources` (issue 39)
 * Removed support for Python 2.7 through Python 3.7 (MR 37)
+* Fixed a defect in `coilmq.util.frames.FrameBuffer.extract_frame`: on
+  an `IncompleteFrame` error, this method set the buffer's next write
+  index to the read index (rather than the end of the buffer) causing
+  the subsequent `FrameBuffer.append()` call(s) to overwrite the
+  beginning of the frame and hanging the server (issue 44)
 
 1.0.1
 -----

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -118,3 +118,27 @@ class BasicTest(BaseFunctionalTestCase):
         res = c1.received_frames.get()
         self.assertEqual(res.cmd, frames.MESSAGE)
         self.assertEqual(res.body, utf8msg)
+
+    def test_send_large_message(self):
+        """
+        Test sending a large message after a short one.
+        """
+        c1 = self._new_client()
+        c1.subscribe('/queue/foo')
+
+        shortmessage = b'x'
+        longmessage = b'y' * 1024 * 16
+
+        c2 = self._new_client()
+
+        c2.send('/queue/foo', shortmessage)
+
+        res = c1.received_frames.get()
+        self.assertEqual(res.cmd, frames.MESSAGE)
+        self.assertEqual(res.body, shortmessage)
+
+        c2.send('/queue/foo', longmessage)
+
+        res2 = c1.received_frames.get()
+        self.assertEqual(res2.cmd, frames.MESSAGE)
+        self.assertEqual(res2.body, longmessage)


### PR DESCRIPTION
This work is based on #22 by @jhb.

Closes #44 