### PR TITLE
format project code with ruff

### DIFF
--- a/coilmq/__init__.py
+++ b/coilmq/__init__.py
@@ -1,4 +1,5 @@
 """Top-level CoilMQ package."""
+
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");

--- a/coilmq/auth/__init__.py
+++ b/coilmq/auth/__init__.py
@@ -4,6 +4,7 @@ Because authentication providers are instantiated and configured in the applicat
 (and not in the request handler), the authenticator implementations must be thread-safe.
 """
 import abc
+
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");

--- a/coilmq/auth/__init__.py
+++ b/coilmq/auth/__init__.py
@@ -3,6 +3,7 @@
 Because authentication providers are instantiated and configured in the application scope
 (and not in the request handler), the authenticator implementations must be thread-safe.
 """
+
 import abc
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']

--- a/coilmq/auth/simple.py
+++ b/coilmq/auth/simple.py
@@ -1,4 +1,5 @@
 """A simple config-file based authentication module."""
+
 from configparser import ConfigParser
 
 from coilmq.auth import Authenticator
@@ -27,9 +28,9 @@ def make_simple():
     :rtype: SimpleAuthenticator
     :raises ConfigError: If there is a configuration error.
     """
-    authfile = config.get('coilmq', 'auth.simple.file')
+    authfile = config.get("coilmq", "auth.simple.file")
     if not authfile:
-        raise ConfigError('Missing configuration parameter: auth.simple.file')
+        raise ConfigError("Missing configuration parameter: auth.simple.file")
     sa = SimpleAuthenticator()
     sa.from_configfile(authfile)
     return sa
@@ -71,17 +72,17 @@ class SimpleAuthenticator(Authenticator):
             section.
         """
         cfg = ConfigParser()
-        if hasattr(configfile, 'read'):
+        if hasattr(configfile, "read"):
             cfg.read_file(configfile)
         else:
             filesread = cfg.read(configfile)
             if not filesread:
-                raise ValueError(f'Could not parse auth file: {configfile}')
+                raise ValueError(f"Could not parse auth file: {configfile}")
 
-        if not cfg.has_section('auth'):
-            raise ValueError('Config file contains no [auth] section.')
+        if not cfg.has_section("auth"):
+            raise ValueError("Config file contains no [auth] section.")
 
-        self.store = dict(cfg.items('auth'))
+        self.store = dict(cfg.items("auth"))
 
     def authenticate(self, login, passcode):
         """Authenticate the login and passcode.

--- a/coilmq/config/__init__.py
+++ b/coilmq/config/__init__.py
@@ -10,6 +10,7 @@ function during application initialization::
     config.getint('listen_port')
 
 """
+
 import importlib
 import logging
 import logging.config
@@ -32,7 +33,7 @@ limitations under the License."""
 
 #: The global configuration object containing the default configuration.
 config = ConfigParser()
-config.read(os.path.join(os.path.dirname(__file__), 'defaults.cfg'))
+config.read(os.path.join(os.path.dirname(__file__), "defaults.cfg"))
 
 
 def init_config(config_file=None):
@@ -84,7 +85,7 @@ def init_logging(logfile=None, loglevel=logging.INFO, configfile=None):
     if configfile and os.path.exists(configfile):
         testcfg = ConfigParser()
         read = testcfg.read(configfile)
-        use_configfile = (read and testcfg.has_section('loggers'))
+        use_configfile = read and testcfg.has_section("loggers")
 
     if use_configfile:
         logging.config.fileConfig(configfile)
@@ -92,10 +93,11 @@ def init_logging(logfile=None, loglevel=logging.INFO, configfile=None):
             msg = "Config file conflicts with explicitly specified logfile; config file takes precedence."
             logging.warning(msg)  # noqa: LOG015
     else:
-        log_format = '%(asctime)s [%(threadName)s] %(name)s - %(levelname)s - %(message)s'
+        log_format = (
+            "%(asctime)s [%(threadName)s] %(name)s - %(levelname)s - %(message)s"
+        )
         if logfile:
-            logging.basicConfig(
-                filename=logfile, level=loglevel, format=log_format)
+            logging.basicConfig(filename=logfile, level=loglevel, format=log_format)
         else:
             logging.basicConfig(level=loglevel, format=log_format)
 
@@ -126,7 +128,7 @@ def resolve_name(name):
     sep_index = max(name.rfind(sep) for sep in (":", "."))
 
     module_name = name[:sep_index]
-    member_name = name[1 + sep_index:]
+    member_name = name[1 + sep_index :]
 
     module = importlib.import_module(module_name)
 

--- a/coilmq/config/__init__.py
+++ b/coilmq/config/__init__.py
@@ -10,13 +10,11 @@ function during application initialization::
     config.getint('listen_port')
 
 """
-import os.path
 import importlib
 import logging
 import logging.config
-
+import os.path
 from configparser import ConfigParser
-
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
@@ -52,8 +50,6 @@ def init_config(config_file=None):
 
     .. seealso:: :func:`init_logging`
     """
-    global config
-
     if config_file and os.path.exists(config_file):
         read = config.read([config_file])
         if not read:
@@ -94,7 +90,7 @@ def init_logging(logfile=None, loglevel=logging.INFO, configfile=None):
         logging.config.fileConfig(configfile)
         if logfile:
             msg = "Config file conflicts with explicitly specified logfile; config file takes precedence."
-            logging.warning(msg)
+            logging.warning(msg)  # noqa: LOG015
     else:
         log_format = '%(asctime)s [%(threadName)s] %(name)s - %(levelname)s - %(message)s'
         if logfile:

--- a/coilmq/engine.py
+++ b/coilmq/engine.py
@@ -1,4 +1,3 @@
-
 from coilmq.protocol import STOMP10
 
 """
@@ -59,11 +58,15 @@ class StompEngine:
 
     """
 
-    def __init__(self, connection, authenticator, queue_manager, topic_manager, protocol=STOMP10):
+    def __init__(
+        self, connection, authenticator, queue_manager, topic_manager, protocol=STOMP10
+    ):
         """:param connection: The stomp connection backing this engine.
         :type connection: coilmq.server.StompConnection
         """
-        self.log = logging.getLogger(f'{self.__class__.__module__}.{self.__class__.__name__}')
+        self.log = logging.getLogger(
+            f"{self.__class__.__module__}.{self.__class__.__name__}"
+        )
         self.connection = connection
         self.authenticator = authenticator
         self.queue_manager = queue_manager

--- a/coilmq/exception.py
+++ b/coilmq/exception.py
@@ -3,6 +3,7 @@
 CoilMQ exceptions extend :py:class:`RuntimeError` or other appropriate sub-classes.  These will be
 thrown if there is not a more appropriate error class already provided by builtins.
 """
+
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");

--- a/coilmq/protocol/__init__.py
+++ b/coilmq/protocol/__init__.py
@@ -13,7 +13,6 @@ from coilmq.util.frames import ErrorFrame, Frame, ReceiptFrame
 
 
 class STOMP(abc.ABC):
-
     def __init__(self, engine):
         self.engine = engine
 
@@ -70,7 +69,6 @@ class STOMP(abc.ABC):
 
 
 class STOMP10(STOMP):
-
     def process_frame(self, frame):
         """Dispatches a received frame to the appropriate internal method.
 
@@ -86,13 +84,12 @@ class STOMP10(STOMP):
             raise ProtocolError("Not connected.")
 
         try:
-            transaction = frame.headers.get('transaction')
+            transaction = frame.headers.get("transaction")
             if not transaction or method in (self.begin, self.commit, self.abort):
                 method(frame)
             else:
                 if transaction not in self.engine.transactions:
-                    raise ProtocolError(
-                        f"Invalid transaction specified: {transaction}")
+                    raise ProtocolError(f"Invalid transaction specified: {transaction}")
                 self.engine.transactions[transaction].append(frame)
         except Exception as e:
             self.engine.log.exception("Error processing STOMP frame")
@@ -106,9 +103,10 @@ class STOMP10(STOMP):
             # the RECEIPT frame should not be sent if there is an error frame.
             # Also we'll assume that a transaction should not preclude sending the receipt
             # frame.
-            if frame.headers.get('receipt') and method != self.connect:
-                self.engine.connection.send_frame(ReceiptFrame(
-                    receipt=frame.headers.get('receipt')))
+            if frame.headers.get("receipt") and method != self.connect:
+                self.engine.connection.send_frame(
+                    ReceiptFrame(receipt=frame.headers.get("receipt"))
+                )
 
     def process_heartbeat(self):
         pass
@@ -121,15 +119,15 @@ class STOMP10(STOMP):
         self.engine.log.debug("CONNECT")
 
         if self.engine.authenticator:
-            login = frame.headers.get('login')
-            passcode = frame.headers.get('passcode')
+            login = frame.headers.get("login")
+            passcode = frame.headers.get("passcode")
             if not self.engine.authenticator.authenticate(login, passcode):
                 raise AuthError(f"Authentication failed for {login}")
 
         self.engine.connected = True
 
         response = response or Frame(frames.CONNECTED)
-        response.headers['session'] = uuid.uuid4()
+        response.headers["session"] = uuid.uuid4()
 
         # TODO: Do we want to do anything special to track sessions?
         # (Actually, I don't think the spec actually does anything with this at all.)
@@ -137,43 +135,51 @@ class STOMP10(STOMP):
 
     def send(self, frame):
         """Handle the SEND command: Delivers a message to a queue or topic (default)."""
-        dest = frame.headers.get('destination')
+        dest = frame.headers.get("destination")
         if not dest:
-            raise ProtocolError('Missing destination for SEND command.')
+            raise ProtocolError("Missing destination for SEND command.")
 
-        if dest.startswith('/queue/'):
+        if dest.startswith("/queue/"):
             self.engine.queue_manager.send(frame)
         else:
             self.engine.topic_manager.send(frame)
 
     def subscribe(self, frame):
         """Handle the SUBSCRIBE command: Adds this connection to destination."""
-        ack = frame.headers.get('ack')
-        reliable = ack and ack.lower() == 'client'
+        ack = frame.headers.get("ack")
+        reliable = ack and ack.lower() == "client"
 
         self.engine.connection.reliable_subscriber = reliable
 
-        dest = frame.headers.get('destination')
+        dest = frame.headers.get("destination")
         if not dest:
-            raise ProtocolError('Missing destination for SUBSCRIBE command.')
+            raise ProtocolError("Missing destination for SUBSCRIBE command.")
 
-        subscription_id = frame.headers.get('id')
-        if dest.startswith('/queue/'):
-            self.engine.queue_manager.subscribe(self.engine.connection, dest, id=subscription_id)
+        subscription_id = frame.headers.get("id")
+        if dest.startswith("/queue/"):
+            self.engine.queue_manager.subscribe(
+                self.engine.connection, dest, id=subscription_id
+            )
         else:
-            self.engine.topic_manager.subscribe(self.engine.connection, dest, id=subscription_id)
+            self.engine.topic_manager.subscribe(
+                self.engine.connection, dest, id=subscription_id
+            )
 
     def unsubscribe(self, frame):
         """Handle the UNSUBSCRIBE command: Removes this connection from destination."""
-        dest = frame.headers.get('destination')
+        dest = frame.headers.get("destination")
         if not dest:
-            raise ProtocolError('Missing destination for UNSUBSCRIBE command.')
+            raise ProtocolError("Missing destination for UNSUBSCRIBE command.")
 
-        subscription_id = frame.headers.get('id')
-        if dest.startswith('/queue/'):
-            self.engine.queue_manager.unsubscribe(self.engine.connection, dest, id=subscription_id)
+        subscription_id = frame.headers.get("id")
+        if dest.startswith("/queue/"):
+            self.engine.queue_manager.unsubscribe(
+                self.engine.connection, dest, id=subscription_id
+            )
         else:
-            self.engine.topic_manager.unsubscribe(self.engine.connection, dest, id=subscription_id)
+            self.engine.topic_manager.unsubscribe(
+                self.engine.connection, dest, id=subscription_id
+            )
 
     def begin(self, frame):
         """Handles BEGIN command: Starts a new transaction."""
@@ -191,11 +197,12 @@ class STOMP10(STOMP):
             raise ProtocolError(f"Invalid transaction: {frame.transaction}")
 
         for tframe in self.engine.transactions[frame.transaction]:
-            del tframe.headers['transaction']
+            del tframe.headers["transaction"]
             self.process_frame(tframe)
 
         self.engine.queue_manager.clear_transaction_frames(
-            self.engine.connection, frame.transaction)
+            self.engine.connection, frame.transaction
+        )
         del self.engine.transactions[frame.transaction]
 
     def abort(self, frame):
@@ -207,14 +214,17 @@ class STOMP10(STOMP):
             raise ProtocolError(f"Invalid transaction: {frame.transaction}")
 
         self.engine.queue_manager.resend_transaction_frames(
-            self.engine.connection, frame.transaction)
+            self.engine.connection, frame.transaction
+        )
         del self.engine.transactions[frame.transaction]
 
     def ack(self, frame):
         """Handles the ACK command: Acknowledges receipt of a message."""
         if "message-id" not in frame.headers:
             raise ProtocolError("No message-id specified for ACK command.")
-        self.engine.queue_manager.ack(self.engine.connection, frame, id=frame.headers.get("id"))
+        self.engine.queue_manager.ack(
+            self.engine.connection, frame, id=frame.headers.get("id")
+        )
 
     def disconnect(self, frame):
         """Handles the DISCONNECT command: Unbinds the connection.
@@ -227,10 +237,16 @@ class STOMP10(STOMP):
 
 
 class STOMP11(STOMP10):
+    SUPPORTED_VERSIONS: ClassVar[set[str]] = {"1.0", "1.1"}
 
-    SUPPORTED_VERSIONS: ClassVar[set[str]] = {'1.0', '1.1'}
-
-    def __init__(self, engine, send_heartbeat_interval=100, receive_heartbeat_interval=100, *args, **kwargs):
+    def __init__(
+        self,
+        engine,
+        send_heartbeat_interval=100,
+        receive_heartbeat_interval=100,
+        *args,
+        **kwargs,
+    ):
         super().__init__(engine)
         self.last_hb = datetime.datetime.now()
         self.last_hb_sent = datetime.datetime.now()
@@ -239,20 +255,33 @@ class STOMP11(STOMP10):
         # flags to control heartbeating
         self.send_hb = self.receive_hb = False
 
-        self.send_heartbeat_interval = datetime.timedelta(milliseconds=send_heartbeat_interval)
-        self.receive_heartbeat_interval = datetime.timedelta(milliseconds=receive_heartbeat_interval)
+        self.send_heartbeat_interval = datetime.timedelta(
+            milliseconds=send_heartbeat_interval
+        )
+        self.receive_heartbeat_interval = datetime.timedelta(
+            milliseconds=receive_heartbeat_interval
+        )
 
     def enable_heartbeat(self, cx, cy, response):
         if self.send_heartbeat_interval and cy:
-            self.send_heartbeat_interval = max(self.send_heartbeat_interval, datetime.timedelta(milliseconds=cy))
-            self.timer.schedule(self.send_heartbeat_interval.total_seconds(), self.send_heartbeat)
+            self.send_heartbeat_interval = max(
+                self.send_heartbeat_interval, datetime.timedelta(milliseconds=cy)
+            )
+            self.timer.schedule(
+                self.send_heartbeat_interval.total_seconds(), self.send_heartbeat
+            )
         if self.receive_heartbeat_interval and cx:
-            self.receive_heartbeat_interval = max(self.send_heartbeat_interval, datetime.timedelta(milliseconds=cx))
-            self.timer.schedule(self.receive_heartbeat_interval.total_seconds(), self.check_receive_heartbeat)
+            self.receive_heartbeat_interval = max(
+                self.send_heartbeat_interval, datetime.timedelta(milliseconds=cx)
+            )
+            self.timer.schedule(
+                self.receive_heartbeat_interval.total_seconds(),
+                self.check_receive_heartbeat,
+            )
         self.timer.start()
         sx = int(self.send_heartbeat_interval / datetime.timedelta(milliseconds=1))
         sy = int(self.receive_heartbeat_interval / datetime.timedelta(milliseconds=1))
-        response.headers['heart-beat'] = f'{sx},{sy}'
+        response.headers["heart-beat"] = f"{sx},{sy}"
 
     def disable_heartbeat(self):
         self.timer.stop()
@@ -266,7 +295,9 @@ class STOMP11(STOMP10):
     def check_receive_heartbeat(self):
         ago = datetime.datetime.now() - self.last_hb
         if ago > (self.receive_heartbeat_interval * 2):
-            self.engine.log.debug("No heartbeat was received for %s seconds", ago.total_seconds())
+            self.engine.log.debug(
+                "No heartbeat was received for %s seconds", ago.total_seconds()
+            )
             self.engine.unbind()
 
     def process_heartbeat(self):
@@ -275,38 +306,42 @@ class STOMP11(STOMP10):
     def connect(self, frame, response=None):
         connected_frame = Frame(frames.CONNECTED)
         self._negotiate_protocol(frame, connected_frame)
-        heart_beat = frame.headers.get('heart-beat', '0,0')
+        heart_beat = frame.headers.get("heart-beat", "0,0")
         if heart_beat:
-            self.enable_heartbeat(*map(int, heart_beat.split(',')), response=connected_frame)
+            self.enable_heartbeat(
+                *map(int, heart_beat.split(",")), response=connected_frame
+            )
         super().connect(frame, response=connected_frame)
 
     def nack(self, frame):
         """Handles the NACK command: Unacknowledges receipt of a message.
         For now, this is just a placeholder to implement this version of the protocol.
         """
-        if not frame.headers.get('message-id'):
+        if not frame.headers.get("message-id"):
             raise ProtocolError("No message-id specified for NACK command.")
-        if not frame.headers.get('subscription'):
+        if not frame.headers.get("subscription"):
             raise ProtocolError("No subscription specified for NACK command.")
 
-        raise NotImplementedError('Nack implementation incomplete')
+        raise NotImplementedError("Nack implementation incomplete")
         # ToDo: self.engine.queue_manager.nack()
 
     def _negotiate_protocol(self, frame, response):
-        client_versions = frame.headers.get('accept-version', '1.0')
+        client_versions = frame.headers.get("accept-version", "1.0")
         if not client_versions:
-            raise ProtocolError('No version specified')
-        common = set(client_versions.split(',')) & self.SUPPORTED_VERSIONS
+            raise ProtocolError("No version specified")
+        common = set(client_versions.split(",")) & self.SUPPORTED_VERSIONS
         if not common:
-            versions = ','.join(self.SUPPORTED_VERSIONS)
-            self.engine.connection.send_frame(Frame(
+            versions = ",".join(self.SUPPORTED_VERSIONS)
+            self.engine.connection.send_frame(
+                Frame(
                     frames.ERROR,
-                    headers={'version': versions, 'content-type': frames.TEXT_PLAIN},
-                    body=f'Supported protocol versions are {versions}'
-            ))
+                    headers={"version": versions, "content-type": frames.TEXT_PLAIN},
+                    body=f"Supported protocol versions are {versions}",
+                )
+            )
         else:
-            response.headers['version'] = max(common)
-            protocol_class = PROTOCOL_MAP[response.headers['version']]
+            response.headers["version"] = max(common)
+            protocol_class = PROTOCOL_MAP[response.headers["version"]]
 
             # Note: `type(obj) is not cls` is the appropriate test.  A test
             # using `instanceof` would lead to false negatives (i.e. the
@@ -331,19 +366,22 @@ class STOMP11(STOMP10):
             raise ProtocolError("No 'subscription' specified for ACK command.")
         if "message-id" not in frame.headers:
             raise ProtocolError("No message-id specified for ACK command.")
-        self.engine.queue_manager.ack(self.engine.connection, frame, id=frame.headers["subscription"])
+        self.engine.queue_manager.ack(
+            self.engine.connection, frame, id=frame.headers["subscription"]
+        )
 
 
 class STOMP12(STOMP11):
-
-    SUPPORTED_VERSIONS: ClassVar[set[str]] = STOMP11.SUPPORTED_VERSIONS.union({'1.2', })
+    SUPPORTED_VERSIONS: ClassVar[set[str]] = STOMP11.SUPPORTED_VERSIONS.union({
+        "1.2",
+    })
 
     def connect(self, frame, response=None):
-        host = frame.headers.get('host')
+        host = frame.headers.get("host")
         if not host:
             raise ProtocolError('"host" header is required')
         if host != socket.getfqdn():
-            raise ProtocolError('Virtual hosting is not supported or host is unknown')
+            raise ProtocolError("Virtual hosting is not supported or host is unknown")
         super().connect(frame, response)
 
     def ack(self, frame):
@@ -351,7 +389,9 @@ class STOMP12(STOMP11):
             raise ProtocolError("No 'id' specified for ACK command.")
         if "message-id" not in frame.headers:
             raise ProtocolError("No message-id specified for ACK command.")
-        self.engine.queue_manager.ack(self.engine.connection, frame, id=frame.headers["id"])
+        self.engine.queue_manager.ack(
+            self.engine.connection, frame, id=frame.headers["id"]
+        )
 
 
-PROTOCOL_MAP = {'1.0': STOMP10, '1.1': STOMP11, '1.2': STOMP12}
+PROTOCOL_MAP = {"1.0": STOMP10, "1.1": STOMP11, "1.2": STOMP12}

--- a/coilmq/protocol/__init__.py
+++ b/coilmq/protocol/__init__.py
@@ -1,12 +1,15 @@
-import abc
-import uuid
-import socket
-import datetime
+from __future__ import annotations
 
-from coilmq.exception import ProtocolError, AuthError
+import abc
+import datetime
+import socket
+import uuid
+from typing import ClassVar
+
+from coilmq.exception import AuthError, ProtocolError
 from coilmq.util import frames
-from coilmq.util.frames import Frame, ErrorFrame, ReceiptFrame
 from coilmq.util.concurrency import CoilThreadingTimer
+from coilmq.util.frames import ErrorFrame, Frame, ReceiptFrame
 
 
 class STOMP(abc.ABC):
@@ -225,7 +228,7 @@ class STOMP10(STOMP):
 
 class STOMP11(STOMP10):
 
-    SUPPORTED_VERSIONS = {'1.0', '1.1'}
+    SUPPORTED_VERSIONS: ClassVar[set[str]] = {'1.0', '1.1'}
 
     def __init__(self, engine, send_heartbeat_interval=100, receive_heartbeat_interval=100, *args, **kwargs):
         super().__init__(engine)
@@ -333,7 +336,7 @@ class STOMP11(STOMP10):
 
 class STOMP12(STOMP11):
 
-    SUPPORTED_VERSIONS = STOMP11.SUPPORTED_VERSIONS.union({'1.2', })
+    SUPPORTED_VERSIONS: ClassVar[set[str]] = STOMP11.SUPPORTED_VERSIONS.union({'1.2', })
 
     def connect(self, frame, response=None):
         host = frame.headers.get('host')

--- a/coilmq/queue.py
+++ b/coilmq/queue.py
@@ -3,6 +3,7 @@
 This code is inspired by the design of the Ruby stompserver project, by
 Patrick Hurley and Lionel Bouton.  See http://stompserver.rubyforge.org/
 """
+
 import logging
 import threading
 import uuid
@@ -70,8 +71,7 @@ class QueueManager:
         :type queue_scheduler: coilmq.scheduler.QueuePriorityScheduler
 
         """
-        self.log = logging.getLogger(
-            f'{__name__}.{self.__class__.__name__}')
+        self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
         # Use default schedulers, if they're not specified
         if subscriber_scheduler is None:
@@ -95,13 +95,13 @@ class QueueManager:
     def close(self):
         """Closes all resources/backends associated with this queue manager."""
         self.log.info("Shutting down queue manager.")
-        if hasattr(self.store, 'close'):
+        if hasattr(self.store, "close"):
             self.store.close()
 
-        if hasattr(self.subscriber_scheduler, 'close'):
+        if hasattr(self.subscriber_scheduler, "close"):
             self.subscriber_scheduler.close()
 
-        if hasattr(self.queue_scheduler, 'close'):
+        if hasattr(self.queue_scheduler, "close"):
             self.queue_scheduler.close()
 
     @synchronized(lock)
@@ -156,8 +156,9 @@ class QueueManager:
         self.log.debug("Disconnecting %s", connection)
         for subscription, pending_frame in list(self._pending.items()):
             if subscription.connection == connection:
-                self.store.requeue(pending_frame.headers.get(
-                    'destination'), pending_frame)
+                self.store.requeue(
+                    pending_frame.headers.get("destination"), pending_frame
+                )
                 del self._pending[subscription]
         self._subscriptions.disconnect(connection)
 
@@ -172,28 +173,28 @@ class QueueManager:
         :param message: The message frame.
         :type message: coilmq.util.frames.Frame
         """
-        dest = message.headers.get('destination')
+        dest = message.headers.get("destination")
         if not dest:
-            raise ValueError(
-                f"Cannot send frame with no destination: {message}")
+            raise ValueError(f"Cannot send frame with no destination: {message}")
 
         message.cmd = MESSAGE
 
-        message.headers.setdefault('message-id', str(uuid.uuid4()))
+        message.headers.setdefault("message-id", str(uuid.uuid4()))
 
         # Grab all subscribers for this destination that do not have pending
         # frames
-        subscribers = [s for s in self._subscriptions.subscribers(dest)
-                       if s not in self._pending]
+        subscribers = [
+            s for s in self._subscriptions.subscribers(dest) if s not in self._pending
+        ]
 
         if not subscribers:
             self.log.debug(
-                "No eligible subscribers; adding message %s to queue %s", message, dest)
+                "No eligible subscribers; adding message %s to queue %s", message, dest
+            )
             self.store.enqueue(dest, message)
         else:
             selected = self.subscriber_scheduler.choice(subscribers, message)
-            self.log.debug("Delivering message %s to subscriber %s",
-                           message, selected)
+            self.log.debug("Delivering message %s to subscriber %s", message, selected)
             self._send_frame(selected, message)
 
     @synchronized(lock)
@@ -217,16 +218,16 @@ class QueueManager:
         if pending_frame is not None:
             # Make sure that the frame being acknowledged matches
             # the expected frame
-            message_id = frame.headers.get('message-id')
-            if pending_frame.headers.get('message-id') != message_id:
-                self.log.warning(
-                    "Got a ACK for unexpected message-id: %s", message_id)
+            message_id = frame.headers.get("message-id")
+            if pending_frame.headers.get("message-id") != message_id:
+                self.log.warning("Got a ACK for unexpected message-id: %s", message_id)
                 self.store.requeue(pending_frame.destination, pending_frame)
                 # (The pending frame will be removed further down)
 
             if transaction is not None:
-                self._transaction_frames[subscription][
-                    transaction].append(pending_frame)
+                self._transaction_frames[subscription][transaction].append(
+                    pending_frame
+                )
 
             self._pending.pop(subscription)
             self._send_backlog(subscription)
@@ -295,14 +296,17 @@ class QueueManager:
                 if subscription in s and self.store.has_frames(dest)
             }
             destination = self.queue_scheduler.choice(
-                eligible_subscriptions, subscription)
+                eligible_subscriptions, subscription
+            )
             if destination is None:
                 self.log.debug(
-                    "No eligible queues (with frames) for subscriber %s", subscription)
+                    "No eligible queues (with frames) for subscriber %s", subscription
+                )
                 return
 
-        self.log.debug("Sending backlog to %s for destination %s",
-                       subscription, destination)
+        self.log.debug(
+            "Sending backlog to %s for destination %s", subscription, destination
+        )
         if subscription.connection.reliable_subscriber:
             # only send one message (waiting for ack)
             frame = self.store.dequeue(destination)
@@ -310,8 +314,7 @@ class QueueManager:
                 try:
                     self._send_frame(subscription, frame)
                 except Exception:
-                    self.log.exception(
-                        "Error sending message %s (requeueing)", frame)
+                    self.log.exception("Error sending message %s (requeueing)", frame)
                     self.store.requeue(destination, frame)
                     raise
         else:
@@ -319,8 +322,7 @@ class QueueManager:
                 try:
                     self._send_frame(subscription, frame)
                 except Exception:
-                    self.log.exception(
-                        "Error sending message %s (requeueing)", frame)
+                    self.log.exception("Error sending message %s (requeueing)", frame)
                     self.store.requeue(destination, frame)
                     raise
 
@@ -342,14 +344,14 @@ class QueueManager:
         if frame.cmd == MESSAGE:
             frame.headers["subscription"] = subscription.id
 
-        self.log.debug("Delivering frame %s to subscription %s",
-                       frame, subscription)
+        self.log.debug("Delivering frame %s to subscription %s", frame, subscription)
 
         if subscription.connection.reliable_subscriber:
             if subscription in self._pending:
                 raise RuntimeError("Connection already has a pending frame.")
             self.log.debug(
-                "Tracking frame %s as pending for subscription %s", frame, subscription)
+                "Tracking frame %s as pending for subscription %s", frame, subscription
+            )
             self._pending[subscription] = frame
 
         subscription.connection.send_frame(frame)

--- a/coilmq/queue.py
+++ b/coilmq/queue.py
@@ -9,9 +9,9 @@ import uuid
 from collections import defaultdict
 
 from coilmq.scheduler import FavorReliableSubscriberScheduler, RandomQueueScheduler
-from coilmq.subscription import SubscriptionManager, Subscription
-from coilmq.util import frames
+from coilmq.subscription import Subscription, SubscriptionManager
 from coilmq.util.concurrency import synchronized
+from coilmq.util.frames import MESSAGE
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
@@ -177,7 +177,7 @@ class QueueManager:
             raise ValueError(
                 f"Cannot send frame with no destination: {message}")
 
-        message.cmd = frames.MESSAGE
+        message.cmd = MESSAGE
 
         message.headers.setdefault('message-id', str(uuid.uuid4()))
 
@@ -289,8 +289,11 @@ class QueueManager:
         """
         if destination is None:
             # Find all destinations that have frames and that contain this subscription.
-            eligible_subscriptions = dict((dest, s) for (dest, s) in self._subscriptions.all_subscribers()
-                                    if subscription in s and self.store.has_frames(dest))
+            eligible_subscriptions = {
+                dest: s
+                for (dest, s) in self._subscriptions.all_subscribers()
+                if subscription in s and self.store.has_frames(dest)
+            }
             destination = self.queue_scheduler.choice(
                 eligible_subscriptions, subscription)
             if destination is None:
@@ -336,7 +339,7 @@ class QueueManager:
         assert subscription is not None
         assert frame is not None
 
-        if frame.cmd == frames.MESSAGE:
+        if frame.cmd == MESSAGE:
             frame.headers["subscription"] = subscription.id
 
         self.log.debug("Delivering frame %s to subscription %s",

--- a/coilmq/scheduler.py
+++ b/coilmq/scheduler.py
@@ -6,6 +6,7 @@ reliable subscribers.  Developers can write their own delivery schedulers, which
 should implement the methods defined in :class:`QueuePriorityScheduler` if they would
 like to customize the behavior.
 """
+
 import abc
 import random
 
@@ -41,7 +42,6 @@ class SubscriberPriorityScheduler(abc.ABC):
             chosen (e.g. list is empty).
         :rtype: coilmq.subscription.Subscription
         """
-
 
 
 class QueuePriorityScheduler(abc.ABC):
@@ -100,7 +100,8 @@ class FavorReliableSubscriberScheduler(SubscriberPriorityScheduler):
         if not subscribers:
             return None
         reliable_subscribers = [
-            s for s in subscribers if s.connection.reliable_subscriber]
+            s for s in subscribers if s.connection.reliable_subscriber
+        ]
         if reliable_subscribers:
             return random.choice(reliable_subscribers)
         else:

--- a/coilmq/server/__init__.py
+++ b/coilmq/server/__init__.py
@@ -3,6 +3,7 @@
 CoilMQ is designed for the Python StompServer reference socket server (specifically
 multi-threaded); however, some alternative implementation examples are also provided.
 """
+
 import abc
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']

--- a/coilmq/server/socket_server.py
+++ b/coilmq/server/socket_server.py
@@ -3,11 +3,10 @@ import logging
 import threading
 from socketserver import BaseRequestHandler, TCPServer, ThreadingMixIn
 
-
-from coilmq.util.frames import FrameBuffer
-from coilmq.server import StompConnection
 from coilmq.engine import StompEngine
 from coilmq.exception import ClientDisconnected
+from coilmq.server import StompConnection
+from coilmq.util.frames import FrameBuffer
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"

--- a/coilmq/server/socket_server.py
+++ b/coilmq/server/socket_server.py
@@ -1,4 +1,5 @@
 """The default/recommended SocketServer-based server implementation."""
+
 import logging
 import threading
 from socketserver import BaseRequestHandler, TCPServer, ThreadingMixIn
@@ -47,13 +48,15 @@ class StompRequestHandler(BaseRequestHandler, StompConnection):
         if self.server.timeout is not None:
             self.request.settimeout(self.server.timeout)
         self.debug = False
-        self.log = logging.getLogger(f'{self.__module__}.{self.__class__.__name__}')
+        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
         self.buffer = FrameBuffer()
-        self.engine = StompEngine(connection=self,
-                                  authenticator=self.server.authenticator,
-                                  queue_manager=self.server.queue_manager,
-                                  topic_manager=self.server.topic_manager,
-                                  protocol=self.server.protocol)
+        self.engine = StompEngine(
+            connection=self,
+            authenticator=self.server.authenticator,
+            queue_manager=self.server.queue_manager,
+            topic_manager=self.server.topic_manager,
+            protocol=self.server.protocol,
+        )
 
     def handle(self):
         """Handle a new socket connection."""
@@ -106,7 +109,7 @@ class StompRequestHandler(BaseRequestHandler, StompConnection):
 
     def send_heartbeat(self):
         """Sends an EOL to connected socket client."""
-        heartbeat = b'\n'
+        heartbeat = b"\n"
         if self.debug:  # pragma: no cover
             self.log.debug("SEND: %r", heartbeat)
         self.request.sendall(heartbeat)
@@ -130,8 +133,16 @@ class StompServer(TCPServer):
     # leave TIME_WAIT after unclean disconnect).
     allow_reuse_address = True
 
-    def __init__(self, server_address, RequestHandlerClass=None, timeout=3.0,
-                 authenticator=None, queue_manager=None, topic_manager=None, protocol=None):
+    def __init__(
+        self,
+        server_address,
+        RequestHandlerClass=None,
+        timeout=3.0,
+        authenticator=None,
+        queue_manager=None,
+        topic_manager=None,
+        protocol=None,
+    ):
         """Extension to :py:class:`TCPServer` constructor to provide mechanism for providing implementation classes.
 
         :param server_address: The (address,port) :py:class:`tuple`
@@ -144,8 +155,7 @@ class StompServer(TCPServer):
         :param topic_manager: The configured :class:`coilmq.topic.TopicManager` object
             to use.
         """
-        self.log = logging.getLogger(
-            f'{self.__module__}.{self.__class__.__name__}')
+        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
         if not RequestHandlerClass:
             RequestHandlerClass = StompRequestHandler
         self.timeout = timeout
@@ -163,7 +173,7 @@ class StompServer(TCPServer):
         TCPServer.server_close(self)
         self.queue_manager.close()
         self.topic_manager.close()
-        if hasattr(self.authenticator, 'close'):
+        if hasattr(self.authenticator, "close"):
             self.authenticator.close()
         self.shutdown()
 

--- a/coilmq/start.py
+++ b/coilmq/start.py
@@ -1,4 +1,5 @@
 """Entrypoint for starting the application."""
+
 import logging
 import os
 import threading
@@ -6,7 +7,7 @@ import time
 import warnings
 from contextlib import contextmanager
 
-is_nt = os.name == 'nt'
+is_nt = os.name == "nt"
 
 if not is_nt:
     import daemon as pydaemon
@@ -60,32 +61,49 @@ def server_from_config(config=None, server_class=None, additional_kwargs=None):
     if not config:
         config = global_config
 
-    queue_store_factory = resolve_name(config.get('coilmq', 'qstore.factory'))
-    subscriber_scheduler_factory = resolve_name(config.get(
-            'coilmq', 'scheduler.subscriber_priority_factory'))
-    queue_scheduler_factory = resolve_name(config.get(
-            'coilmq', 'scheduler.queue_priority_factory'))
+    queue_store_factory = resolve_name(config.get("coilmq", "qstore.factory"))
+    subscriber_scheduler_factory = resolve_name(
+        config.get("coilmq", "scheduler.subscriber_priority_factory")
+    )
+    queue_scheduler_factory = resolve_name(
+        config.get("coilmq", "scheduler.queue_priority_factory")
+    )
 
-    if config.has_option('coilmq', 'auth.factory'):
-        authenticator_factory = resolve_name(
-                config.get('coilmq', 'auth.factory'))
+    if config.has_option("coilmq", "auth.factory"):
+        authenticator_factory = resolve_name(config.get("coilmq", "auth.factory"))
         authenticator = authenticator_factory()
     else:
         authenticator = None
 
-    server = ThreadedStompServer((config.get('coilmq', 'listen_addr'), config.getint('coilmq', 'listen_port')),
-                                 queue_manager=QueueManager(store=queue_store_factory(),
-                                                            subscriber_scheduler=subscriber_scheduler_factory(),
-                                                            queue_scheduler=queue_scheduler_factory()),
-                                 topic_manager=TopicManager(),
-                                 authenticator=authenticator,
-                                 protocol=STOMP11)
+    server = ThreadedStompServer(
+        (config.get("coilmq", "listen_addr"), config.getint("coilmq", "listen_port")),
+        queue_manager=QueueManager(
+            store=queue_store_factory(),
+            subscriber_scheduler=subscriber_scheduler_factory(),
+            queue_scheduler=queue_scheduler_factory(),
+        ),
+        topic_manager=TopicManager(),
+        authenticator=authenticator,
+        protocol=STOMP11,
+    )
     logger.info("Created server:%r", server)
     return server
 
 
-def context_serve(context, configfile, listen_addr, listen_port, logfile,
-                  debug, daemon, uid, gid, pidfile, umask, rundir):
+def context_serve(
+    context,
+    configfile,
+    listen_addr,
+    listen_port,
+    logfile,
+    debug,
+    daemon,
+    uid,
+    gid,
+    pidfile,
+    umask,
+    rundir,
+):
     """Takes a context object, which implements the __enter__/__exit__ "with" interface
     and starts a server within that context.
 
@@ -111,32 +129,37 @@ def context_serve(context, configfile, listen_addr, listen_port, logfile,
             # We've got no stderr/stdout here; and so (to my knowledge) no reliable (& cross-platform),
             # way to display errors.
             level = logging.DEBUG if debug else logging.INFO
-            init_logging(logfile=logfile, loglevel=level,
-                         configfile=configfile)
+            init_logging(logfile=logfile, loglevel=level, configfile=configfile)
 
             server = server_from_config()
             logger.info("Stomp server listening on %s:%s", *server.server_address)
 
             if debug:
-                poll_interval = float(global_config.get(
-                        'coilmq', 'debug.stats_poll_interval'))
+                poll_interval = float(
+                    global_config.get("coilmq", "debug.stats_poll_interval")
+                )
                 if poll_interval:  # Setting poll_interval to 0 effectively disables it.
+
                     def diagnostic_loop(server):
                         log = logger
                         while True:
-                            log.debug(
-                                    "Stats heartbeat -------------------------------")
+                            log.debug("Stats heartbeat -------------------------------")
                             store = server.queue_manager.store
                             for dest in store.destinations():
-                                log.debug("Queue %s: size=%s, subscribers=%s",
-                                    dest, store.size(dest), server.queue_manager.subscriber_count(dest))
+                                log.debug(
+                                    "Queue %s: size=%s, subscribers=%s",
+                                    dest,
+                                    store.size(dest),
+                                    server.queue_manager.subscriber_count(dest),
+                                )
 
                             # TODO: Add number of subscribers?
 
                             time.sleep(poll_interval)
 
                     diagnostic_thread = threading.Thread(
-                            target=diagnostic_loop, name='DiagnosticThread', args=(server,))
+                        target=diagnostic_loop, name="DiagnosticThread", args=(server,)
+                    )
                     diagnostic_thread.daemon = True
                     diagnostic_thread.start()
 
@@ -153,8 +176,19 @@ def context_serve(context, configfile, listen_addr, listen_port, logfile,
             server.server_close()
 
 
-def _main(config=None, host=None, port=None, logfile=None, debug=None,
-          daemon=None, uid=None, gid=None, pidfile=None, umask=None, rundir=None):
+def _main(
+    config=None,
+    host=None,
+    port=None,
+    logfile=None,
+    debug=None,
+    daemon=None,
+    uid=None,
+    gid=None,
+    pidfile=None,
+    umask=None,
+    rundir=None,
+):
 
     # Note that we must initialize the configuration before we enter the context
     # block; however, we _cannot_ initialize logging until we are in the context block
@@ -162,37 +196,100 @@ def _main(config=None, host=None, port=None, logfile=None, debug=None,
     init_config(config)
 
     if host is not None:
-        global_config.set('coilmq', 'listen_addr', host)
+        global_config.set("coilmq", "listen_addr", host)
 
     if port is not None:
-        global_config.set('coilmq', 'listen_port', str(port))
+        global_config.set("coilmq", "listen_port", str(port))
 
         if daemon and is_nt:
-            warnings.warn("Daemon context is not available for NT platform", stacklevel=2)
+            warnings.warn(
+                "Daemon context is not available for NT platform", stacklevel=2
+            )
 
     # in an on-daemon mode, we use a dummy context object
     # so we can use the same run-server code as the daemon version.
-    context = pydaemon.DaemonContext(uid=uid,
-                                     gid=gid,
-                                     pidfile=pid.PidFile(pidname=pidfile) if pidfile else None,
-                                     umask=int(umask, 8),
-                                     working_directory=rundir) if daemon and pydaemon else contextmanager(lambda: (yield))()
+    context = (
+        pydaemon.DaemonContext(
+            uid=uid,
+            gid=gid,
+            pidfile=pid.PidFile(pidname=pidfile) if pidfile else None,
+            umask=int(umask, 8),
+            working_directory=rundir,
+        )
+        if daemon and pydaemon
+        else contextmanager(lambda: (yield))()
+    )
 
-    context_serve(context, config, host, port, logfile, debug, daemon, uid, gid, pidfile, umask, rundir)
+    context_serve(
+        context,
+        config,
+        host,
+        port,
+        logfile,
+        debug,
+        daemon,
+        uid,
+        gid,
+        pidfile,
+        umask,
+        rundir,
+    )
 
 
 @click.command()
-@click.option("-c", "--config", help="Read configuration from FILE. (CLI options override config file.)", metavar="FILE")
-@click.option("-b", "--host", help="Listen on specified address (default 127.0.0.1)", metavar="ADDR")
-@click.option("-p", "--port", help="Listen on specified port (default 61613)", type=int, metavar="PORT")
-@click.option("-l", "--logfile", help="Log to specified file (unless logging configured in config file).", metavar="FILE")
-@click.option("--debug", default=False, is_flag=True, help="Sets logging to debug (unless logging configured in config file).")
-@click.option("-d", "--daemon", default=False, is_flag=True, help="Run server as a daemon (default False).")
-@click.option("-u", "--uid", help="The user/UID to use for daemon process.", metavar="UID")
-@click.option("-g", "--gid", help="The group/GID to use for daemon process.", metavar="GID")
-@click.option("--pidfile",   help="The PID file to use.", metavar="FILE")
-@click.option("--umask", help="Umask (octal) to apply for daemonized process.", metavar="MASK")
-@click.option('--rundir', help="The working directory to use for the daemonized process (default /).", metavar="DIR")
+@click.option(
+    "-c",
+    "--config",
+    help="Read configuration from FILE. (CLI options override config file.)",
+    metavar="FILE",
+)
+@click.option(
+    "-b",
+    "--host",
+    help="Listen on specified address (default 127.0.0.1)",
+    metavar="ADDR",
+)
+@click.option(
+    "-p",
+    "--port",
+    help="Listen on specified port (default 61613)",
+    type=int,
+    metavar="PORT",
+)
+@click.option(
+    "-l",
+    "--logfile",
+    help="Log to specified file (unless logging configured in config file).",
+    metavar="FILE",
+)
+@click.option(
+    "--debug",
+    default=False,
+    is_flag=True,
+    help="Sets logging to debug (unless logging configured in config file).",
+)
+@click.option(
+    "-d",
+    "--daemon",
+    default=False,
+    is_flag=True,
+    help="Run server as a daemon (default False).",
+)
+@click.option(
+    "-u", "--uid", help="The user/UID to use for daemon process.", metavar="UID"
+)
+@click.option(
+    "-g", "--gid", help="The group/GID to use for daemon process.", metavar="GID"
+)
+@click.option("--pidfile", help="The PID file to use.", metavar="FILE")
+@click.option(
+    "--umask", help="Umask (octal) to apply for daemonized process.", metavar="MASK"
+)
+@click.option(
+    "--rundir",
+    help="The working directory to use for the daemonized process (default /).",
+    metavar="DIR",
+)
 def main(config, host, port, logfile, debug, daemon, uid, gid, pidfile, umask, rundir):
     """Main entry point for running a socket server from the commandline.
 
@@ -203,7 +300,7 @@ def main(config, host, port, logfile, debug, daemon, uid, gid, pidfile, umask, r
     _main(**locals())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         main()
     except (KeyboardInterrupt, SystemExit):

--- a/coilmq/start.py
+++ b/coilmq/start.py
@@ -1,11 +1,8 @@
-#!python
 """Entrypoint for starting the application."""
-import os
 import logging
-
-
-import time
+import os
 import threading
+import time
 import warnings
 from contextlib import contextmanager
 
@@ -19,11 +16,12 @@ else:
 
 import click
 
-from coilmq.config import config as global_config, init_config, init_logging, resolve_name
+from coilmq.config import config as global_config
+from coilmq.config import init_config, init_logging, resolve_name
 from coilmq.protocol import STOMP11
-from coilmq.topic import TopicManager
 from coilmq.queue import QueueManager
 from coilmq.server.socket_server import ThreadedStompServer
+from coilmq.topic import TopicManager
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
@@ -59,7 +57,6 @@ def server_from_config(config=None, server_class=None, additional_kwargs=None):
     :returns: The configured StompServer.
     :rtype: coilmq.server.socket_server.StompServer
     """
-    global global_config
     if not config:
         config = global_config
 
@@ -106,8 +103,6 @@ def context_serve(context, configfile, listen_addr, listen_port, logfile,
 
     .. seealso:: :func:`server_from_config`
     """
-    global global_config
-
     server = None
     try:
         with context:

--- a/coilmq/store/__init__.py
+++ b/coilmq/store/__init__.py
@@ -1,4 +1,5 @@
 """Storage containers for durable queues and (planned) durable topics."""
+
 import abc
 import logging
 import threading
@@ -37,8 +38,7 @@ class QueueStore(abc.ABC):
         If you extend this class, you should either call this method or at minimum make sure these values
         get set.
         """
-        self.log = logging.getLogger(
-            f'{self.__module__}.{self.__class__.__name__}')
+        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
 
     @abc.abstractmethod
     @synchronized(lock)

--- a/coilmq/store/__init__.py
+++ b/coilmq/store/__init__.py
@@ -113,7 +113,7 @@ class QueueStore(abc.ABC):
         """
         raise NotImplementedError
 
-    @synchronized(lock)  # noqa: B027
+    @synchronized(lock)
     def close(self):
         """May be implemented to perform any necessary cleanup operations when store is closed."""
 

--- a/coilmq/store/dbm.py
+++ b/coilmq/store/dbm.py
@@ -7,6 +7,7 @@ Because of how the :py:mod:`shelve` module works (and how we're using it) and ca
 documentation this is likely a BAD storage module to use if you are expecting to traffic in
 large frames.
 """
+
 import os
 import os.path
 import shelve
@@ -40,20 +41,21 @@ lock = threading.RLock()
 def make_dbm():
     """Creates a DBM queue store, pulling config values from the CoilMQ configuration."""
     try:
-        data_dir = config.get('coilmq', 'qstore.dbm.data_dir')
-        cp_ops = config.getint('coilmq', 'qstore.dbm.checkpoint_operations')
-        cp_timeout = config.getint('coilmq', 'qstore.dbm.checkpoint_timeout')
+        data_dir = config.get("coilmq", "qstore.dbm.data_dir")
+        cp_ops = config.getint("coilmq", "qstore.dbm.checkpoint_operations")
+        cp_timeout = config.getint("coilmq", "qstore.dbm.checkpoint_timeout")
     except NoOptionError as e:
-        raise ConfigError(f'Missing configuration parameter: {e}') from e
+        raise ConfigError(f"Missing configuration parameter: {e}") from e
 
     if not os.path.exists(data_dir):
-        raise ConfigError(f'DBM directory does not exist: {data_dir}')
+        raise ConfigError(f"DBM directory does not exist: {data_dir}")
     # FIXME: how do these get applied? Is OR appropriate?
     if not os.access(data_dir, os.W_OK | os.R_OK):
-        raise ConfigError(f'Cannot read and write DBM directory: {data_dir}')
+        raise ConfigError(f"Cannot read and write DBM directory: {data_dir}")
 
-    store = DbmQueue(data_dir, checkpoint_operations=cp_ops,
-                     checkpoint_timeout=cp_timeout)
+    store = DbmQueue(
+        data_dir, checkpoint_operations=cp_ops, checkpoint_timeout=cp_timeout
+    )
     return store
 
 
@@ -117,15 +119,23 @@ class DbmQueue(QueueStore):
         # The queue metadata stores mutable (dict) objects.  For this reason we set
         # writeback=True and rely on the sync() method to keep the cache & disk
         # in-sync.
-        self.queue_metadata = shelve.open(os.path.join(  # noqa: SIM115
-            self.data_dir, 'metadata'), writeback=True)
+        self.queue_metadata = shelve.open(
+            os.path.join(  # noqa: SIM115
+                self.data_dir, "metadata"
+            ),
+            writeback=True,
+        )
 
         # Since we do not need mutable objects on the frame stores (we don't modify them, we just
         # put/get values), we do NOT use writeback=True here.  This should also conserve on memory
         # usage, since apparently that can get hefty with the caching when
         # writeback=True.
-        self.frame_store = shelve.open(os.path.join(  # noqa: SIM115
-            self.data_dir, 'frames'), writeback=False)
+        self.frame_store = shelve.open(
+            os.path.join(  # noqa: SIM115
+                self.data_dir, "frames"
+            ),
+            writeback=False,
+        )
 
     @synchronized(lock)
     def enqueue(self, destination, frame):
@@ -137,18 +147,24 @@ class DbmQueue(QueueStore):
         :type frame: coilmq.util.frames.Frame
 
         """
-        message_id = frame.headers.get('message-id')
+        message_id = frame.headers.get("message-id")
         if not message_id:
             raise ValueError("Cannot queue a frame without message-id set.")
 
         if not destination in self.queue_metadata:
             self.log.info(
-                "Destination %s not in metadata; creating new entry and queue database.", destination)
+                "Destination %s not in metadata; creating new entry and queue database.",
+                destination,
+            )
             self.queue_metadata[destination] = {
-                'frames': deque(), 'enqueued': 0, 'dequeued': 0, 'size': 0}
+                "frames": deque(),
+                "enqueued": 0,
+                "dequeued": 0,
+                "size": 0,
+            }
 
-        self.queue_metadata[destination]['frames'].appendleft(message_id)
-        self.queue_metadata[destination]['enqueued'] += 1
+        self.queue_metadata[destination]["frames"].appendleft(message_id)
+        self.queue_metadata[destination]["enqueued"] += 1
 
         self.frame_store[message_id] = frame
 
@@ -169,8 +185,8 @@ class DbmQueue(QueueStore):
         if not self.has_frames(destination):
             return None
 
-        message_id = self.queue_metadata[destination]['frames'].pop()
-        self.queue_metadata[destination]['dequeued'] += 1
+        message_id = self.queue_metadata[destination]["frames"].pop()
+        self.queue_metadata[destination]["dequeued"] += 1
 
         frame = self.frame_store[message_id]
         del self.frame_store[message_id]
@@ -190,7 +206,9 @@ class DbmQueue(QueueStore):
         :returns: Whether there are any frames in the specified queue.
         :rtype: bool
         """
-        return (destination in self.queue_metadata) and bool(self.queue_metadata[destination]['frames'])
+        return (destination in self.queue_metadata) and bool(
+            self.queue_metadata[destination]["frames"]
+        )
 
     @synchronized(lock)
     def size(self, destination):
@@ -205,7 +223,7 @@ class DbmQueue(QueueStore):
         if not destination in self.queue_metadata:
             return 0
         else:
-            return len(self.queue_metadata[destination]['frames'])
+            return len(self.queue_metadata[destination]["frames"])
 
     @synchronized(lock)
     def close(self):
@@ -230,8 +248,10 @@ class DbmQueue(QueueStore):
 
         In this implementation, this method wraps calls to :py:meth:`shelve.Shelf.sync`.
         """
-        if (self._opcount > self.checkpoint_operations or
-                datetime.now() > self._last_sync + self.checkpoint_timeout):
+        if (
+            self._opcount > self.checkpoint_operations
+            or datetime.now() > self._last_sync + self.checkpoint_timeout
+        ):
             self.log.debug("Synchronizing queue metadata.")
             self.queue_metadata.sync()
             self._last_sync = datetime.now()

--- a/coilmq/store/dbm.py
+++ b/coilmq/store/dbm.py
@@ -7,18 +7,17 @@ Because of how the :py:mod:`shelve` module works (and how we're using it) and ca
 documentation this is likely a BAD storage module to use if you are expecting to traffic in
 large frames.
 """
-import threading
 import os
 import os.path
 import shelve
+import threading
 from collections import deque
+from configparser import NoOptionError
 from datetime import datetime, timedelta
-from configparser import ConfigParser, NoOptionError
 
-
-from coilmq.store import QueueStore
 from coilmq.config import config
 from coilmq.exception import ConfigError
+from coilmq.store import QueueStore
 from coilmq.util.concurrency import synchronized
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
@@ -118,14 +117,14 @@ class DbmQueue(QueueStore):
         # The queue metadata stores mutable (dict) objects.  For this reason we set
         # writeback=True and rely on the sync() method to keep the cache & disk
         # in-sync.
-        self.queue_metadata = shelve.open(os.path.join(
+        self.queue_metadata = shelve.open(os.path.join(  # noqa: SIM115
             self.data_dir, 'metadata'), writeback=True)
 
         # Since we do not need mutable objects on the frame stores (we don't modify them, we just
         # put/get values), we do NOT use writeback=True here.  This should also conserve on memory
         # usage, since apparently that can get hefty with the caching when
         # writeback=True.
-        self.frame_store = shelve.open(os.path.join(
+        self.frame_store = shelve.open(os.path.join(  # noqa: SIM115
             self.data_dir, 'frames'), writeback=False)
 
     @synchronized(lock)

--- a/coilmq/store/memory.py
+++ b/coilmq/store/memory.py
@@ -1,4 +1,5 @@
 """Queue storage module that uses thread-safe, in-memory data structures."""
+
 import threading
 from collections import defaultdict, deque
 

--- a/coilmq/store/rds.py
+++ b/coilmq/store/rds.py
@@ -5,13 +5,16 @@ import threading
 try:
     import redis
 except ImportError:  # pragma: no cover
-    sys.exit('please, install redis-py package to use redis-store')
+    sys.exit("please, install redis-py package to use redis-store")
 
 from coilmq.config import config
 from coilmq.store import QueueStore
 from coilmq.util.concurrency import synchronized
 
-__authors__ = ('"Hans Lellelid" <hans@xmpl.org>', '"Alexander Zhukov" <zhukovaa90@gmail.com>')
+__authors__ = (
+    '"Hans Lellelid" <hans@xmpl.org>',
+    '"Alexander Zhukov" <zhukovaa90@gmail.com>',
+)
 __copyright__ = "Copyright 2009 Hans Lellelid"
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,7 +33,8 @@ lock = threading.RLock()
 
 def make_redis_store(cfg=None):
     return RedisQueueStore(
-        redis_conn=redis.Redis(**dict((cfg or config).items('redis'))))
+        redis_conn=redis.Redis(**dict((cfg or config).items("redis")))
+    )
 
 
 class RedisQueueStore(QueueStore):

--- a/coilmq/store/rds.py
+++ b/coilmq/store/rds.py
@@ -1,13 +1,15 @@
+import pickle
+import sys
+import threading
+
 try:
     import redis
 except ImportError:  # pragma: no cover
-    import sys; sys.exit('please, install redis-py package to use redis-store')
-import threading
-import pickle
+    sys.exit('please, install redis-py package to use redis-store')
 
+from coilmq.config import config
 from coilmq.store import QueueStore
 from coilmq.util.concurrency import synchronized
-from coilmq.config import config
 
 __authors__ = ('"Hans Lellelid" <hans@xmpl.org>', '"Alexander Zhukov" <zhukovaa90@gmail.com>')
 __copyright__ = "Copyright 2009 Hans Lellelid"

--- a/coilmq/store/sa/__init__.py
+++ b/coilmq/store/sa/__init__.py
@@ -1,4 +1,5 @@
 """Queue storage module that uses SQLAlchemy to access queue information and frames in a database."""
+
 from sqlalchemy import MetaData, engine_from_config
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.sql import distinct, func, select
@@ -24,8 +25,8 @@ limitations under the License."""
 
 def make_sa():
     """Factory to creates a SQLAlchemy queue store, pulling config values from the CoilMQ configuration."""
-    configuration = dict(config.items('coilmq'))
-    engine = engine_from_config(configuration, 'qstore.sqlalchemy.')
+    configuration = dict(config.items("coilmq"))
+    engine = engine_from_config(configuration, "qstore.sqlalchemy.")
     init_model(engine)
     store = SAQueue()
     return store
@@ -75,11 +76,12 @@ class SAQueue(QueueStore):
 
         """
         session = meta.Session()
-        message_id = frame.headers.get('message-id')
+        message_id = frame.headers.get("message-id")
         if not message_id:
             raise ValueError("Cannot queue a frame without message-id set.")
         ins = model.frames_table.insert().values(
-            message_id=message_id, destination=destination, frame=frame)
+            message_id=message_id, destination=destination, frame=frame
+        )
         session.execute(ins)
         session.commit()
 
@@ -96,13 +98,14 @@ class SAQueue(QueueStore):
         session = meta.Session()
 
         try:
-
-            selstmt = select(
-                [model.frames_table.c.message_id, model.frames_table.c.frame])
-            selstmt = selstmt.where(
-                model.frames_table.c.destination == destination)
+            selstmt = select([
+                model.frames_table.c.message_id,
+                model.frames_table.c.frame,
+            ])
+            selstmt = selstmt.where(model.frames_table.c.destination == destination)
             selstmt = selstmt.order_by(
-                model.frames_table.c.queued, model.frames_table.c.sequence)
+                model.frames_table.c.queued, model.frames_table.c.sequence
+            )
 
             result = session.execute(selstmt)
 
@@ -110,8 +113,10 @@ class SAQueue(QueueStore):
             if not first:
                 return None
 
-            delstmt = model.frames_table.delete().where(model.frames_table.c.message_id ==
-                                                        first[model.frames_table.c.message_id])
+            delstmt = model.frames_table.delete().where(
+                model.frames_table.c.message_id
+                == first[model.frames_table.c.message_id]
+            )
             session.execute(delstmt)
 
             frame = first[model.frames_table.c.frame]
@@ -134,7 +139,8 @@ class SAQueue(QueueStore):
         """
         session = meta.Session()
         sel = select([model.frames_table.c.message_id]).where(
-            model.frames_table.c.destination == destination)
+            model.frames_table.c.destination == destination
+        )
         result = session.execute(sel)
 
         first = result.fetchone()
@@ -151,7 +157,8 @@ class SAQueue(QueueStore):
         """
         session = meta.Session()
         sel = select([func.count(model.frames_table.c.message_id)]).where(
-            model.frames_table.c.destination == destination)
+            model.frames_table.c.destination == destination
+        )
         result = session.execute(sel)
         first = result.fetchone()
         if not first:

--- a/coilmq/store/sa/__init__.py
+++ b/coilmq/store/sa/__init__.py
@@ -1,10 +1,10 @@
 """Queue storage module that uses SQLAlchemy to access queue information and frames in a database."""
-from sqlalchemy import engine_from_config, MetaData
+from sqlalchemy import MetaData, engine_from_config
 from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.sql import select, func, distinct
+from sqlalchemy.sql import distinct, func, select
 
-from coilmq.store import QueueStore
 from coilmq.config import config
+from coilmq.store import QueueStore
 from coilmq.store.sa import meta, model
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']

--- a/coilmq/store/sa/meta.py
+++ b/coilmq/store/sa/meta.py
@@ -2,6 +2,7 @@
 
 These objects are set by the :func:`coilmq.store.sa.init_model` function.
 """
+
 #: The SA engine.
 engine = None
 

--- a/coilmq/store/sa/model.py
+++ b/coilmq/store/sa/model.py
@@ -36,13 +36,15 @@ def setup_tables(create=True, drop=False):
 
     """
     global frames_table
-    frames_table = Table('frames', meta.metadata,
-                         Column('message_id', String(255), primary_key=True),
-                         Column('sequence', BigInteger,
-                                primary_key=False, autoincrement=True),
-                         Column('destination', String(255), index=True),
-                         Column('frame', PickleType),
-                         Column('queued', DateTime, default=func.now()))
+    frames_table = Table(
+        "frames",
+        meta.metadata,
+        Column("message_id", String(255), primary_key=True),
+        Column("sequence", BigInteger, primary_key=False, autoincrement=True),
+        Column("destination", String(255), index=True),
+        Column("frame", PickleType),
+        Column("queued", DateTime, default=func.now()),
+    )
 
     if drop:
         meta.metadata.drop_all()

--- a/coilmq/store/sa/model.py
+++ b/coilmq/store/sa/model.py
@@ -1,6 +1,6 @@
 """Definition of the data model required for SA storage backend."""
 
-from sqlalchemy import Table, Column, BigInteger, String, PickleType, DateTime
+from sqlalchemy import BigInteger, Column, DateTime, PickleType, String, Table
 from sqlalchemy.sql import func
 
 from coilmq.store.sa import meta

--- a/coilmq/subscription.py
+++ b/coilmq/subscription.py
@@ -1,7 +1,8 @@
 import itertools
-from dataclasses import dataclass
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any
+
 from coilmq.server import StompConnection
 
 DEFAULT_SUBSCRIPTION_ID = 0

--- a/coilmq/topic.py
+++ b/coilmq/topic.py
@@ -7,6 +7,7 @@ import logging
 import threading
 import uuid
 from copy import deepcopy
+
 from coilmq.subscription import SubscriptionManager
 from coilmq.util import frames
 from coilmq.util.concurrency import synchronized
@@ -120,7 +121,7 @@ class TopicManager:
             frame.headers["subscription"] = subscriber.id
             try:
                 subscriber.connection.send_frame(frame)
-            except:
+            except:  # noqa: E722
                 self.log.exception(
                     "Error delivering message to subscriber %s; client will be disconnected.", subscriber)
                 # We queue for deletion so we are not modifying the topics dict

--- a/coilmq/topic.py
+++ b/coilmq/topic.py
@@ -3,6 +3,7 @@
 This code is inspired by the design of the Ruby stompserver project, by
 Patrick Hurley and Lionel Bouton.  See http://stompserver.rubyforge.org/
 """
+
 import logging
 import threading
 import uuid
@@ -44,8 +45,7 @@ class TopicManager:
     """
 
     def __init__(self):
-        self.log = logging.getLogger(
-            f'{__name__}.{self.__class__.__name__}')
+        self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
         # Lock var is required for L{synchronized} decorator.
         self._lock = threading.RLock()
@@ -106,14 +106,13 @@ class TopicManager:
             to MESSAGE and set a message id.)
         :type message: coilmq.util.frames.Frame
         """
-        dest = message.headers.get('destination')
+        dest = message.headers.get("destination")
         if not dest:
-            raise ValueError(
-                "Cannot send frame with no destination: {message}")
+            raise ValueError("Cannot send frame with no destination: {message}")
 
         message.cmd = frames.MESSAGE
 
-        message.headers.setdefault('message-id', str(uuid.uuid4()))
+        message.headers.setdefault("message-id", str(uuid.uuid4()))
 
         bad_subscribers = set()
         for subscriber in self._subscriptions.subscribers(dest):
@@ -123,7 +122,9 @@ class TopicManager:
                 subscriber.connection.send_frame(frame)
             except:  # noqa: E722
                 self.log.exception(
-                    "Error delivering message to subscriber %s; client will be disconnected.", subscriber)
+                    "Error delivering message to subscriber %s; client will be disconnected.",
+                    subscriber,
+                )
                 # We queue for deletion so we are not modifying the topics dict
                 # while iterating over it.
                 bad_subscribers.add(subscriber)

--- a/coilmq/util/__init__.py
+++ b/coilmq/util/__init__.py
@@ -1,4 +1,5 @@
 """CoilMQ utility modules."""
+
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");

--- a/coilmq/util/concurrency.py
+++ b/coilmq/util/concurrency.py
@@ -1,8 +1,8 @@
 """Tools to facilitate developing thread-safe components."""
 
 import abc
-import threading
 import functools
+import threading
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"

--- a/coilmq/util/concurrency.py
+++ b/coilmq/util/concurrency.py
@@ -29,16 +29,18 @@ def synchronized(lock):
         :param func: Method to decorate
         :type func: callable
         """
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             with lock:
                 return func(*args, **kwargs)
+
         return wrapper
+
     return synchronize
 
 
 class CoilTimerBase(abc.ABC):
-
     def __init__(self, *args, **kwargs):
         self.jobs = []
 
@@ -68,7 +70,6 @@ class CoilTimerBase(abc.ABC):
 # <http://stackoverflow.com/questions/2124540/how-does-timer-in-python-work-regarding-mutlithreading>
 # <http://stackoverflow.com/questions/12435211/python-threading-timer-repeat-function-every-n-seconds>
 class CoilThreadingTimer(CoilTimerBase):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._running = False
@@ -83,7 +84,9 @@ class CoilThreadingTimer(CoilTimerBase):
     def run(self):
         def run_job(index, interval, callback):
             if self._running:
-                self._timers[index] = threading.Timer(period, run_job, (index, interval, callback)).start()
+                self._timers[index] = threading.Timer(
+                    period, run_job, (index, interval, callback)
+                ).start()
                 callback()
 
         self._reset_timers()

--- a/coilmq/util/frames.py
+++ b/coilmq/util/frames.py
@@ -1,7 +1,7 @@
-import re
-import logging
-from collections import OrderedDict
 import io
+import logging
+import re
+from collections import OrderedDict
 from itertools import starmap
 
 SEND = 'SEND'
@@ -37,16 +37,16 @@ class EmptyBuffer(Exception):
     """The buffer is empty."""
 
 
-def parse_headers(buff):
+def parse_headers(buff: io.BytesIO):
     """Parses buffer and returns command and headers as strings.
 
     :param buff: Buffer containing frame
     :type buff: io.BytesIO
     """
-    preamble_lines = list(map(
-        lambda x: x.decode(),
-        iter(lambda: buff.readline().strip(), b''))
-    )
+    preamble_lines = [
+        line.decode()
+        for line in iter(lambda: buff.readline().strip(), b'')
+    ]
     if not preamble_lines:
         raise EmptyBuffer()
     return preamble_lines[0], OrderedDict([l.split(':') for l in preamble_lines[1:]])
@@ -172,7 +172,7 @@ class HeaderValue:
         :type calculator: callable
         """
         if not callable(calculator):
-            raise ValueError("Non-callable param: {calculator}")
+            raise TypeError("Non-callable param: {calculator}")
         self.calc = calculator
 
     def __get__(self, obj, objtype):

--- a/coilmq/util/frames.py
+++ b/coilmq/util/frames.py
@@ -4,25 +4,39 @@ import re
 from collections import OrderedDict
 from itertools import starmap
 
-SEND = 'SEND'
-CONNECT = 'CONNECT'
-MESSAGE = 'MESSAGE'
-ERROR = 'ERROR'
-CONNECTED = 'CONNECTED'
-SUBSCRIBE = 'SUBSCRIBE'
-UNSUBSCRIBE = 'UNSUBSCRIBE'
-BEGIN = 'BEGIN'
-COMMIT = 'COMMIT'
-ABORT = 'ABORT'
-ACK = 'ACK'
-NACK = 'NACK'
-STOMP_CMD = 'STOMP'
-DISCONNECT = 'DISCONNECT'
+SEND = "SEND"
+CONNECT = "CONNECT"
+MESSAGE = "MESSAGE"
+ERROR = "ERROR"
+CONNECTED = "CONNECTED"
+SUBSCRIBE = "SUBSCRIBE"
+UNSUBSCRIBE = "UNSUBSCRIBE"
+BEGIN = "BEGIN"
+COMMIT = "COMMIT"
+ABORT = "ABORT"
+ACK = "ACK"
+NACK = "NACK"
+STOMP_CMD = "STOMP"
+DISCONNECT = "DISCONNECT"
 
-VALID_COMMANDS = [MESSAGE, CONNECT, CONNECTED, ERROR, SEND,
-                  SUBSCRIBE, UNSUBSCRIBE, BEGIN, COMMIT, ABORT, ACK, DISCONNECT, NACK, STOMP_CMD]
+VALID_COMMANDS = [
+    MESSAGE,
+    CONNECT,
+    CONNECTED,
+    ERROR,
+    SEND,
+    SUBSCRIBE,
+    UNSUBSCRIBE,
+    BEGIN,
+    COMMIT,
+    ABORT,
+    ACK,
+    DISCONNECT,
+    NACK,
+    STOMP_CMD,
+]
 
-TEXT_PLAIN = 'text/plain'
+TEXT_PLAIN = "text/plain"
 
 
 class IncompleteFrame(Exception):
@@ -44,12 +58,11 @@ def parse_headers(buff: io.BytesIO):
     :type buff: io.BytesIO
     """
     preamble_lines = [
-        line.decode()
-        for line in iter(lambda: buff.readline().strip(), b'')
+        line.decode() for line in iter(lambda: buff.readline().strip(), b"")
     ]
     if not preamble_lines:
         raise EmptyBuffer()
-    return preamble_lines[0], OrderedDict([l.split(':') for l in preamble_lines[1:]])
+    return preamble_lines[0], OrderedDict([l.split(":") for l in preamble_lines[1:]])
 
 
 def parse_body(buff, headers):
@@ -59,7 +72,7 @@ def parse_body(buff, headers):
     :type headers: dict
 
     """
-    content_length = int(headers.get('content-length', -1))
+    content_length = int(headers.get("content-length", -1))
     body = buff.read(content_length)
     if content_length >= 0:
         if len(body) < content_length:
@@ -69,7 +82,7 @@ def parse_body(buff, headers):
             raise BodyNotTerminated()
     else:
         # no content length
-        body, terminator, rest = body.partition(b'\x00')
+        body, terminator, rest = body.partition(b"\x00")
         if not terminator:
             raise BodyNotTerminated()
         else:
@@ -89,21 +102,23 @@ class Frame:
     def __init__(self, cmd, headers=None, body=None):
         self.cmd = cmd
         self.headers = headers or {}
-        self.body = body or ''
+        self.body = body or ""
 
     def __str__(self):
-        return f'{{cmd={self.cmd},headers=[{self.headers}],body={self.body if isinstance(self.body, bytes) else self.body.encode()}}}'
+        return f"{{cmd={self.cmd},headers=[{self.headers}],body={self.body if isinstance(self.body, bytes) else self.body.encode()}}}"
 
     def __eq__(self, other):
         """Override equality checking to test for matching command, headers, and body."""
-        return all([isinstance(other, Frame),
-                    self.cmd == other.cmd,
-                    self.headers == other.headers,
-                    self.body == other.body])
+        return all([
+            isinstance(other, Frame),
+            self.cmd == other.cmd,
+            self.headers == other.headers,
+            self.body == other.body,
+        ])
 
     @property
     def transaction(self):
-        return self.headers.get('transaction')
+        return self.headers.get("transaction")
 
     @classmethod
     def from_buffer(cls, buff):
@@ -117,20 +132,25 @@ class Frame:
         :returns: The string (bytes) for this stomp frame.
         :rtype: str
         """
-        self.headers.setdefault('content-length', len(self.body))
+        self.headers.setdefault("content-length", len(self.body))
 
         # See https://stomp.github.io/stomp-specification-1.1.html#Augmented_BNF
         return (
             # command LF
-            self.cmd.encode() + b"\n" +
+            self.cmd.encode()
+            + b"\n"
+            +
             # *( header LF )
-            "".join(starmap("{0}:{1}\n".format, self.headers.items())).encode() +
+            "".join(starmap("{0}:{1}\n".format, self.headers.items())).encode()
+            +
             # LF
-            b"\n" +
+            b"\n"
+            +
             # *OCTET
-            (self.body if isinstance(self.body, bytes) else self.body.encode()) +
+            (self.body if isinstance(self.body, bytes) else self.body.encode())
+            +
             # NULL
-            b'\x00'
+            b"\x00"
         )
 
 
@@ -145,9 +165,8 @@ class ConnectedFrame(Frame):
         """:param session: The (throw-away) session ID to include in response.
         :type session: str
         """
-        super().__init__(
-            cmd=CONNECTED, headers=extra_headers or {})
-        self.headers['session'] = session
+        super().__init__(cmd=CONNECTED, headers=extra_headers or {})
+        self.headers["session"] = session
 
 
 class HeaderValue:
@@ -185,7 +204,7 @@ class HeaderValue:
         self.calc = value
 
     def __repr__(self):
-        return f'<{self.__class__.__name__} calculator={self.calc}>'
+        return f"<{self.__class__.__name__} calculator={self.calc}>"
 
 
 class ErrorFrame(Frame):
@@ -195,14 +214,12 @@ class ErrorFrame(Frame):
         """:param body: The message body bytes.
         :type body: str
         """
-        super().__init__(cmd=ERROR,
-                                         headers=extra_headers or {}, body=body)
-        self.headers['message'] = message
-        self.headers[
-            'content-length'] = HeaderValue(calculator=lambda: len(self.body))
+        super().__init__(cmd=ERROR, headers=extra_headers or {}, body=body)
+        self.headers["message"] = message
+        self.headers["content-length"] = HeaderValue(calculator=lambda: len(self.body))
 
     def __repr__(self):
-        return f'<{self.__class__.__name__} message={self.headers["message"]!r}>'
+        return f"<{self.__class__.__name__} message={self.headers['message']!r}>"
 
 
 class ReceiptFrame(Frame):
@@ -212,9 +229,8 @@ class ReceiptFrame(Frame):
         """:param receipt: The receipt message ID.
         :type receipt: str
         """
-        super().__init__(
-            'RECEIPT', headers=extra_headers or {})
-        self.headers['receipt-id'] = receipt
+        super().__init__("RECEIPT", headers=extra_headers or {})
+        self.headers["receipt-id"] = receipt
 
 
 class FrameBuffer:
@@ -237,23 +253,23 @@ class FrameBuffer:
     """
 
     # regexp to check that the buffer starts with a command.
-    command_re = re.compile('^(.+?)\n')
+    command_re = re.compile("^(.+?)\n")
 
     # regexp to remove everything up to and including the first
     # instance of '\x00' (used in resyncing the buffer).
-    sync_re = re.compile('^.*?\x00')
+    sync_re = re.compile("^.*?\x00")
 
     # regexp to determine the content length. The buffer should always start
     # with a command followed by the headers, so the content-length header will
     # always be preceded by a newline.  It may not always proceeded by a
     # newline, though!
-    content_length_re = re.compile('\ncontent-length\\s*:\\s*(\\d+)\\s*(\n|$)')
+    content_length_re = re.compile("\ncontent-length\\s*:\\s*(\\d+)\\s*(\n|$)")
 
     def __init__(self):
         self._buffer = io.BytesIO()
         self._pointer = 0
         self.debug = False
-        self.log = logging.getLogger(f'{self.__module__}.{self.__class__.__name__}')
+        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
 
     def clear(self):
         """Clears (empties) the internal buffer."""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,7 @@ extensions = [
 
 exclude_patterns = [
     ".DS_Store",
-    ".gitignore"
-    "Thumbs.db",
+    ".gitignoreThumbs.db",
     "_build",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,14 +88,14 @@ keep_full_version = true
 ini_options.addopts = "--doctest-modules --cov=coilmq --cov=tests"
 ini_options.python_files = "*.py"
 
-[tool.coverage.report]
-exclude_also = [
+[tool.coverage]
+report.exclude_also = [
     "def __repr__",
+    "if __name__ == '__main__':",
+    "if 0:",
     "if self.debug:",
     "if settings.DEBUG",
     "raise AssertionError",
     "raise NotImplementedError",
     "raise NotImplementedError()",
-    "if 0:",
-    "if __name__ == '__main__':",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,14 @@ packages = [ "coilmq" ]
 
 [tool.setuptools_scm]
 
+[tool.ruff]
+line-length = 88
+preview = true
+lint.ignore = [
+    "DTZ001", # call-datetime-without-tzinfo
+    "DTZ005", # call-datetime-now-without-tzinfo
+]
+
 [tool.pyproject-fmt]
 indent = 4
 keep_full_version = true

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 """Unit and functional tests for project."""
+
 import coilmq.config
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,23 +1,23 @@
 """Functional tests to test full stack (but not actual socket layer)."""
-import sys
-import time
-import unittest
 import logging
-import socket
 import select
+import socket
 import threading
+import unittest
+from queue import Queue
 
-from queue import Queue, Empty
-
-from coilmq.util.frames import Frame, FrameBuffer
+from coilmq.protocol import STOMP10
 from coilmq.queue import QueueManager
+from coilmq.scheduler import FavorReliableSubscriberScheduler, RandomQueueScheduler
+from coilmq.server.socket_server import (
+    StompRequestHandler,
+    StompServer,
+    ThreadedStompServer,
+)
+from coilmq.store.memory import MemoryQueue
 from coilmq.topic import TopicManager
 from coilmq.util import frames
-from coilmq.server.socket_server import StompServer, StompRequestHandler, ThreadedStompServer
-from coilmq.store.memory import MemoryQueue
-from coilmq.scheduler import FavorReliableSubscriberScheduler, RandomQueueScheduler
-from coilmq.protocol import STOMP10
-
+from coilmq.util.frames import Frame, FrameBuffer
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
@@ -198,7 +198,7 @@ class TestStompClient:
 
     def _read_loop(self):
         while self.connected:
-            r, w, e = select.select([self.sock], [], [], 0.1)
+            r, *_ = select.select([self.sock], [], [], 0.1)
             if r:
                 data = self.sock.recv(1024)
                 self.buffer.append(data)

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,4 +1,5 @@
 """Functional tests to test full stack (but not actual socket layer)."""
+
 import logging
 import select
 import socket
@@ -52,17 +53,18 @@ class BaseFunctionalTestCase(unittest.TestCase):
         addr_bound = threading.Event()
 
         def start_server():
-            self.server = TestStompServer(('127.0.0.1', 0),
-                                          ready_event=self.ready_event,
-                                          authenticator=None,
-                                          queue_manager=self._queuemanager(),
-                                          topic_manager=self._topicmanager())
+            self.server = TestStompServer(
+                ("127.0.0.1", 0),
+                ready_event=self.ready_event,
+                authenticator=None,
+                queue_manager=self._queuemanager(),
+                topic_manager=self._topicmanager(),
+            )
             self.server_address = self.server.socket.getsockname()
             addr_bound.set()
             self.server.serve_forever()
 
-        self.server_thread = threading.Thread(
-            target=start_server, name='server')
+        self.server_thread = threading.Thread(target=start_server, name="server")
         self.server_thread.start()
         self.ready_event.wait()
         addr_bound.wait()
@@ -74,9 +76,11 @@ class BaseFunctionalTestCase(unittest.TestCase):
 
         :rtype: QueueManager
         """
-        return QueueManager(store=MemoryQueue(),
-                            subscriber_scheduler=FavorReliableSubscriberScheduler(),
-                            queue_scheduler=RandomQueueScheduler())
+        return QueueManager(
+            store=MemoryQueue(),
+            subscriber_scheduler=FavorReliableSubscriberScheduler(),
+            queue_scheduler=RandomQueueScheduler(),
+        )
 
     def _topicmanager(self):
         """Returns the configured :class:`TopicManager` instance to use.
@@ -121,17 +125,24 @@ class TestStompServer(ThreadedStompServer):
 
     allow_reuse_address = True
 
-    def __init__(self, server_address,
-                 ready_event=None,
-                 authenticator=None,
-                 queue_manager=None,
-                 topic_manager=None):
+    def __init__(
+        self,
+        server_address,
+        ready_event=None,
+        authenticator=None,
+        queue_manager=None,
+        topic_manager=None,
+    ):
         self.ready_event = ready_event
-        StompServer.__init__(self, server_address, StompRequestHandler,
-                             authenticator=authenticator,
-                             queue_manager=queue_manager,
-                             topic_manager=topic_manager,
-                             protocol=STOMP10)
+        StompServer.__init__(
+            self,
+            server_address,
+            StompRequestHandler,
+            authenticator=authenticator,
+            queue_manager=queue_manager,
+            topic_manager=topic_manager,
+            protocol=STOMP10,
+        )
 
     def server_activate(self):
         self.ready_event.set()
@@ -155,7 +166,7 @@ class TestStompClient:
         :type connect: bool
 
         """
-        self.log = logging.getLogger(f'{self.__module__}.{self.__class__.__name__}')
+        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
         self.sock = None
         self.addr = addr
         self.received_frames = Queue()
@@ -169,14 +180,13 @@ class TestStompClient:
 
     def send(self, destination, message, set_content_length=True, extra_headers=None):
         headers = extra_headers or {}
-        headers['destination'] = destination
+        headers["destination"] = destination
         if set_content_length:
-            headers['content-length'] = len(message)
+            headers["content-length"] = len(message)
         self.send_frame(Frame(frames.SEND, headers=headers, body=message))
 
     def subscribe(self, destination):
-        self.send_frame(Frame(frames.SUBSCRIBE, headers={
-                        'destination': destination}))
+        self.send_frame(Frame(frames.SUBSCRIBE, headers={"destination": destination}))
 
     def send_frame(self, frame):
         """Sends a stomp frame.
@@ -192,8 +202,9 @@ class TestStompClient:
         self.sock.connect(self.addr)
         self.connected = True
         self.read_stopped.clear()
-        t = threading.Thread(target=self._read_loop,
-                             name=f"client-receiver-{hex(id(self))}")
+        t = threading.Thread(
+            target=self._read_loop, name=f"client-receiver-{hex(id(self))}"
+        )
         t.start()
 
     def _read_loop(self):

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -2,10 +2,11 @@
 scheduler implementations.
 """
 import zlib
+from queue import Empty as QueueEmpty
 
 from coilmq.auth.simple import SimpleAuthenticator
 from coilmq.util import frames
-from tests.functional import BaseFunctionalTestCase, Empty as QueueEmpty
+from tests.functional import BaseFunctionalTestCase
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
@@ -27,7 +28,7 @@ class BasicTest(BaseFunctionalTestCase):
 
     def test_connect(self):
         """Test a basic (non-auth) connection."""
-        c = self._new_client()
+        self._new_client()
 
     def test_connect_auth(self):
         """Test connecting when auth is required."""
@@ -54,7 +55,7 @@ class BasicTest(BaseFunctionalTestCase):
     def test_send_receipt(self):
         c1 = self._new_client()
         c1.send('/topic/foo', 'A message', extra_headers={'receipt': 'FOOBAR'})
-        r = c1.received_frames.get(timeout=1)
+        c1.received_frames.get(timeout=1)
 
     def test_subscribe(self):
         c1 = self._new_client()

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -1,6 +1,7 @@
 """Functional tests that use the default memory-based storage backends and default
 scheduler implementations.
 """
+
 import zlib
 from queue import Empty as QueueEmpty
 
@@ -32,44 +33,44 @@ class BasicTest(BaseFunctionalTestCase):
 
     def test_connect_auth(self):
         """Test connecting when auth is required."""
-        self.server.authenticator = SimpleAuthenticator(store={'user': 'pass'})
+        self.server.authenticator = SimpleAuthenticator(store={"user": "pass"})
 
         c1 = self._new_client(connect=False)
         c1.connect()
         r = c1.received_frames.get(timeout=1)
         self.assertEqual(r.cmd, frames.ERROR)
-        self.assertIn(b'Auth', r.body)
+        self.assertIn(b"Auth", r.body)
 
         c2 = self._new_client(connect=False)
-        c2.connect(headers={'login': 'user', 'passcode': 'pass'})
+        c2.connect(headers={"login": "user", "passcode": "pass"})
         r2 = c2.received_frames.get(timeout=1)
 
         self.assertEqual(r2.cmd, frames.CONNECTED)
 
         c3 = self._new_client(connect=False)
-        c3.connect(headers={'login': 'user', 'passcode': 'pass-invalid'})
+        c3.connect(headers={"login": "user", "passcode": "pass-invalid"})
         r3 = c3.received_frames.get(timeout=1)
 
         self.assertEqual(r3.cmd, frames.ERROR)
 
     def test_send_receipt(self):
         c1 = self._new_client()
-        c1.send('/topic/foo', 'A message', extra_headers={'receipt': 'FOOBAR'})
+        c1.send("/topic/foo", "A message", extra_headers={"receipt": "FOOBAR"})
         c1.received_frames.get(timeout=1)
 
     def test_subscribe(self):
         c1 = self._new_client()
-        c1.subscribe('/queue/foo')
+        c1.subscribe("/queue/foo")
 
         c2 = self._new_client()
-        c2.subscribe('/queue/foo2')
+        c2.subscribe("/queue/foo2")
 
-        c2.send('/queue/foo', 'A message')
+        c2.send("/queue/foo", "A message")
         self.assertEqual(c2.received_frames.qsize(), 0)
 
         r = c1.received_frames.get()
         self.assertEqual(r.cmd, frames.MESSAGE)
-        self.assertEqual(r.body, b'A message')
+        self.assertEqual(r.body, b"A message")
 
     def test_disconnect(self):
         """Test the 'polite' disconnect."""
@@ -83,13 +84,13 @@ class BasicTest(BaseFunctionalTestCase):
     def test_send_binary(self):
         """Test sending binary data."""
         c1 = self._new_client()
-        c1.subscribe('/queue/foo')
+        c1.subscribe("/queue/foo")
 
         # Read some random binary data.
         # (This should be cross-platform.)
-        message = b'This is the message that will be compressed.'
+        message = b"This is the message that will be compressed."
         c2 = self._new_client()
-        c2.send('/queue/foo', zlib.compress(message))
+        c2.send("/queue/foo", zlib.compress(message))
 
         res = c1.received_frames.get()
         self.assertEqual(res.cmd, frames.MESSAGE)
@@ -98,14 +99,14 @@ class BasicTest(BaseFunctionalTestCase):
     def test_send_utf8(self):
         """Test sending utf-8-encoded strings."""
         c1 = self._new_client()
-        c1.subscribe('/queue/foo')
+        c1.subscribe("/queue/foo")
 
-        unicodemsg = '我能吞下玻璃而不伤身体'
-        utf8msg = unicodemsg.encode('utf-8')
+        unicodemsg = "我能吞下玻璃而不伤身体"
+        utf8msg = unicodemsg.encode("utf-8")
 
         c2 = self._new_client()
 
-        c2.send('/queue/foo', utf8msg)
+        c2.send("/queue/foo", utf8msg)
 
         res = c1.received_frames.get()
         self.assertEqual(res.cmd, frames.MESSAGE)
@@ -114,20 +115,20 @@ class BasicTest(BaseFunctionalTestCase):
     def test_send_large_message(self):
         """Test sending a large message after a short one."""
         c1 = self._new_client()
-        c1.subscribe('/queue/foo')
+        c1.subscribe("/queue/foo")
 
-        shortmessage = b'x'
-        longmessage = b'y' * 1024 * 16
+        shortmessage = b"x"
+        longmessage = b"y" * 1024 * 16
 
         c2 = self._new_client()
 
-        c2.send('/queue/foo', shortmessage)
+        c2.send("/queue/foo", shortmessage)
 
         res = c1.received_frames.get()
         self.assertEqual(res.cmd, frames.MESSAGE)
         self.assertEqual(res.body, shortmessage)
 
-        c2.send('/queue/foo', longmessage)
+        c2.send("/queue/foo", longmessage)
 
         res2 = c1.received_frames.get()
         self.assertEqual(res2.cmd, frames.MESSAGE)

--- a/tests/functional/test_basic_sa.py
+++ b/tests/functional/test_basic_sa.py
@@ -1,6 +1,7 @@
 """Functional tests that use a SQLite storage backends and default
 scheduler implementations.
 """
+
 import os
 import os.path
 
@@ -31,14 +32,16 @@ class BasicSqlAlchemyStoreTest(BasicTest):
 
     def _queuemanager(self):
         """Returns the configured :class:`QueueManager` instance to use."""
-        data_dir = os.path.join(os.getcwd(), 'data')
+        data_dir = os.path.join(os.getcwd(), "data")
         if not os.path.exists(data_dir):
             os.makedirs(data_dir)
-        configuration = {'qstore.sqlalchemy.url': 'sqlite:///data/coilmq.db'}
-        engine = engine_from_config(configuration, 'qstore.sqlalchemy.')
+        configuration = {"qstore.sqlalchemy.url": "sqlite:///data/coilmq.db"}
+        engine = engine_from_config(configuration, "qstore.sqlalchemy.")
         init_model(engine, drop=True)
         store = SAQueue()
 
-        return QueueManager(store=store,
-                            subscriber_scheduler=FavorReliableSubscriberScheduler(),
-                            queue_scheduler=RandomQueueScheduler())
+        return QueueManager(
+            store=store,
+            subscriber_scheduler=FavorReliableSubscriberScheduler(),
+            queue_scheduler=RandomQueueScheduler(),
+        )

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -1,4 +1,5 @@
 """Classes to be used for mock objects."""
+
 from collections import defaultdict
 
 from coilmq import auth
@@ -19,7 +20,6 @@ limitations under the License."""
 
 
 class MockConnection:
-
     def __init__(self):
         self.frames = []
         self.heartbeat_count = 0
@@ -37,22 +37,20 @@ class MockConnection:
 
 
 class MockSubscription:
-
     def __init__(self):
         self.id = 0
         self.connection = MockConnection()
 
 
 class MockAuthenticator(auth.Authenticator):
-    LOGIN = 'foo'
-    PASSCODE = 'bar'
+    LOGIN = "foo"
+    PASSCODE = "bar"
 
     def authenticate(self, login, passcode):
-        return (login == self.LOGIN and passcode == self.PASSCODE)
+        return login == self.LOGIN and passcode == self.PASSCODE
 
 
 class MockQueueManager:
-
     def __init__(self):
         self.reset()
 
@@ -110,7 +108,6 @@ class MockQueueManager:
 
 
 class MockTopicManager:
-
     def __init__(self):
         self.reset()
 

--- a/tests/protocol/__init__.py
+++ b/tests/protocol/__init__.py
@@ -3,7 +3,12 @@ import unittest
 from coilmq.engine import StompEngine
 from coilmq.protocol import STOMP12
 from coilmq.util.frames import Frame
-from tests.mock import (MockAuthenticator, MockConnection, MockQueueManager, MockTopicManager)
+from tests.mock import (
+    MockAuthenticator,
+    MockConnection,
+    MockQueueManager,
+    MockTopicManager,
+)
 
 
 class ProtocolBaseTestCase(unittest.TestCase):

--- a/tests/protocol/__init__.py
+++ b/tests/protocol/__init__.py
@@ -12,7 +12,6 @@ from tests.mock import (
 
 
 class ProtocolBaseTestCase(unittest.TestCase):
-
     def get_protocol(self):
         return STOMP12
 
@@ -21,13 +20,15 @@ class ProtocolBaseTestCase(unittest.TestCase):
         self.tm = MockTopicManager()
         self.conn = MockConnection()
         self.auth = MockAuthenticator()
-        self.engine = StompEngine(connection=self.conn,
-                                  queue_manager=self.qm,
-                                  topic_manager=self.tm,
-                                  authenticator=None,
-                                  protocol=self.get_protocol())
+        self.engine = StompEngine(
+            connection=self.conn,
+            queue_manager=self.qm,
+            topic_manager=self.tm,
+            authenticator=None,
+            protocol=self.get_protocol(),
+        )
 
-    def feed_frame(self, cmd, headers=None, body=''):
+    def feed_frame(self, cmd, headers=None, body=""):
         self.engine.process_frame(Frame(cmd, headers or {}, body))
         return self.conn.frames[-1]
 

--- a/tests/protocol/test_1_1.py
+++ b/tests/protocol/test_1_1.py
@@ -8,7 +8,6 @@ from tests.protocol import ProtocolBaseTestCase
 
 
 class STOMP11TestCase(ProtocolBaseTestCase):
-
     def get_protocol(self):
         return STOMP11
 
@@ -22,13 +21,23 @@ class STOMP11TestCase(ProtocolBaseTestCase):
 
     def test_heartbeat_from_server(self):
         with self.with_heartbeat(self.engine.protocol):
-            self.engine.process_frame(Frame(frames.CONNECT, headers={'heart-beat': '0,100', 'accept-version': '1.1'}))
+            self.engine.process_frame(
+                Frame(
+                    frames.CONNECT,
+                    headers={"heart-beat": "0,100", "accept-version": "1.1"},
+                )
+            )
             time.sleep(0.53)
             self.assertAlmostEqual(self.conn.heartbeat_count, 5, delta=1)
 
     def test_no_heartbeat_from_client(self):
         with self.with_heartbeat(STOMP11(self.engine, receive_heartbeat_interval=50)):
-            self.engine.process_frame(Frame(frames.CONNECT, headers={'heart-beat': '50,50', 'accept-version': '1.1'}))
+            self.engine.process_frame(
+                Frame(
+                    frames.CONNECT,
+                    headers={"heart-beat": "50,50", "accept-version": "1.1"},
+                )
+            )
             self.assertTrue(self.engine.connected)
             self.assertTrue(self.engine.protocol.timer._running)
             time.sleep(0.53)
@@ -36,25 +45,36 @@ class STOMP11TestCase(ProtocolBaseTestCase):
 
     def test_no_heartbeat(self):
         with self.with_heartbeat(STOMP11(self.engine)):
-            self.engine.process_frame(Frame(frames.CONNECT, headers={'heart-beat': '0,0', 'accept-version': '1.1'}))
+            self.engine.process_frame(
+                Frame(
+                    frames.CONNECT,
+                    headers={"heart-beat": "0,0", "accept-version": "1.1"},
+                )
+            )
             self.assertTrue(self.engine.connected)
             self.assertTrue(self.engine.protocol.timer._running)
 
     def test_protocol_version_common_exists(self):
-        self.engine.process_frame(Frame(frames.CONNECT, headers={'heart-beat': '0,0', 'accept-version': '1.1'}))
+        self.engine.process_frame(
+            Frame(
+                frames.CONNECT, headers={"heart-beat": "0,0", "accept-version": "1.1"}
+            )
+        )
         self.assertEqual(self.conn.frames[-1].cmd, frames.CONNECTED)
-        self.assertIn('version', self.conn.frames[-1].headers)
+        self.assertIn("version", self.conn.frames[-1].headers)
 
     def test_nack_valid_frame(self):
         self.engine.connected = True
-        self.engine.process_frame(Frame(frames.NACK, headers={'message-id': 1, 'subscription': 'foo'}))
+        self.engine.process_frame(
+            Frame(frames.NACK, headers={"message-id": 1, "subscription": "foo"})
+        )
         # just make sure it works
         self.assertTrue(1)
 
     def test_nack_invalid_frame(self):
         self.engine.connected = True
 
-        self.engine.process_frame(Frame(frames.NACK, headers={'subscription': 'foo'}))
+        self.engine.process_frame(Frame(frames.NACK, headers={"subscription": "foo"}))
         self.assertIsInstance(self.conn.frames[-1], ErrorFrame)
-        self.engine.process_frame(Frame(frames.NACK, headers={'message-id': 1}))
+        self.engine.process_frame(Frame(frames.NACK, headers={"message-id": 1}))
         self.assertIsInstance(self.conn.frames[-1], ErrorFrame)

--- a/tests/protocol/test_1_1.py
+++ b/tests/protocol/test_1_1.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 from coilmq.protocol import STOMP11
 from coilmq.util import frames
-from coilmq.util.frames import Frame, ErrorFrame
+from coilmq.util.frames import ErrorFrame, Frame
 from tests.protocol import ProtocolBaseTestCase
 
 
@@ -15,7 +15,6 @@ class STOMP11TestCase(ProtocolBaseTestCase):
     @contextmanager
     def with_heartbeat(self, protocol):
         try:
-            old = self.engine.protocol
             self.engine.protocol = protocol
             yield
         finally:

--- a/tests/protocol/test_stomp_1_2.py
+++ b/tests/protocol/test_stomp_1_2.py
@@ -6,30 +6,38 @@ from tests.protocol import ProtocolBaseTestCase
 
 
 class STOMP12TestCase(ProtocolBaseTestCase):
-
     def setUp(self):
         super().setUp()
         self.host = socket.getfqdn()
 
     def test_host_valid(self):
-        response = self.feed_frame(frames.CONNECT, {'host': self.host, 'accept-version': '1.2'})
+        response = self.feed_frame(
+            frames.CONNECT, {"host": self.host, "accept-version": "1.2"}
+        )
         self.assertEqual(response.cmd, frames.CONNECTED)
 
     def test_host_invalid(self):
-        host = 'nothing.nowhere.com'
-        response = self.feed_frame(frames.CONNECT, {'host': host, 'accept-version': '1.2'})
+        host = "nothing.nowhere.com"
+        response = self.feed_frame(
+            frames.CONNECT, {"host": host, "accept-version": "1.2"}
+        )
         self.assertEqual(response.cmd, frames.ERROR)
-        self.assertEqual(response.headers['message'], 'Virtual hosting is not supported or host is unknown')
+        self.assertEqual(
+            response.headers["message"],
+            "Virtual hosting is not supported or host is unknown",
+        )
 
     def test_no_host_header(self):
-        response = self.feed_frame(frames.CONNECT, {'accept-version': '1.2'})
+        response = self.feed_frame(frames.CONNECT, {"accept-version": "1.2"})
         self.assertEqual(response.cmd, frames.ERROR)
-        self.assertEqual(response.headers['message'], '"host" header is required')
+        self.assertEqual(response.headers["message"], '"host" header is required')
 
     def test_protocol_downgrade(self):
-        response = self.feed_frame(frames.CONNECT, {'host': self.host, 'accept-version': '1.1'})
+        response = self.feed_frame(
+            frames.CONNECT, {"host": self.host, "accept-version": "1.1"}
+        )
         self.assertEqual(response.cmd, frames.CONNECTED)
-        self.assertEqual(response.headers['version'], '1.1')
+        self.assertEqual(response.headers["version"], "1.1")
         # Note: assertIsInstance is not appropriate here because the test would
         # pass if self.engine.protocol was STOMP10 which is not what we want.
         # `assertIs(type(obj), cls)` is appropriate way to check for an object's

--- a/tests/store/__init__.py
+++ b/tests/store/__init__.py
@@ -1,5 +1,4 @@
 """Queue storage tests."""
-import unittest
 import uuid
 
 from coilmq.util import frames

--- a/tests/store/__init__.py
+++ b/tests/store/__init__.py
@@ -1,4 +1,5 @@
 """Queue storage tests."""
+
 import uuid
 
 from coilmq.util import frames
@@ -27,9 +28,10 @@ class CommonQueueTest:
 
     def test_enqueue(self):
         """Test the enqueue() method."""
-        dest = '/queue/foo'
-        frame = Frame(frames.MESSAGE, headers={
-                      'message-id': str(uuid.uuid4())}, body='some data')
+        dest = "/queue/foo"
+        frame = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="some data"
+        )
         self.store.enqueue(dest, frame)
 
         self.assertTrue(self.store.has_frames(dest))
@@ -37,9 +39,10 @@ class CommonQueueTest:
 
     def test_dequeue(self):
         """Test the dequeue() method."""
-        dest = '/queue/foo'
-        frame = Frame(frames.MESSAGE, headers={
-                      'message-id': str(uuid.uuid4())}, body='some data')
+        dest = "/queue/foo"
+        frame = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="some data"
+        )
         self.store.enqueue(dest, frame)
 
         self.assertTrue(self.store.has_frames(dest))
@@ -56,19 +59,22 @@ class CommonQueueTest:
 
     def test_dequeue_specific(self):
         """Test that we only dequeue from the correct queue."""
-        dest = '/queue/foo'
-        notdest = '/queue/other'
+        dest = "/queue/foo"
+        notdest = "/queue/other"
 
-        frame1 = Frame(frames.MESSAGE, headers={
-                       'message-id': str(uuid.uuid4())}, body='message-1')
+        frame1 = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="message-1"
+        )
         self.store.enqueue(dest, frame1)
 
-        frame2 = Frame(frames.MESSAGE, headers={
-                       'message-id': str(uuid.uuid4())}, body='message-2')
+        frame2 = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="message-2"
+        )
         self.store.enqueue(notdest, frame2)
 
-        frame3 = Frame(frames.MESSAGE, headers={
-                       'message-id': str(uuid.uuid4())}, body='message-3')
+        frame3 = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="message-3"
+        )
         self.store.enqueue(dest, frame3)
 
         self.assertTrue(self.store.has_frames(dest))
@@ -85,18 +91,21 @@ class CommonQueueTest:
 
     def test_dequeue_order(self):
         """Test the order that frames are returned by dequeue() method."""
-        dest = '/queue/foo'
+        dest = "/queue/foo"
 
-        frame1 = Frame(frames.MESSAGE, headers={
-                       'message-id': str(uuid.uuid4())}, body='message-1')
+        frame1 = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="message-1"
+        )
         self.store.enqueue(dest, frame1)
 
-        frame2 = Frame(frames.MESSAGE, headers={
-                       'message-id': str(uuid.uuid4())}, body='message-2')
+        frame2 = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="message-2"
+        )
         self.store.enqueue(dest, frame2)
 
-        frame3 = Frame(frames.MESSAGE, headers={
-                       'message-id': str(uuid.uuid4())}, body='message-3')
+        frame3 = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="message-3"
+        )
         self.store.enqueue(dest, frame3)
 
         self.assertTrue(self.store.has_frames(dest))
@@ -116,7 +125,7 @@ class CommonQueueTest:
 
     def test_dequeue_empty(self):
         """Test dequeue() with empty queue."""
-        self.assertIsNone(self.store.dequeue('/queue/nonexist'))
+        self.assertIsNone(self.store.dequeue("/queue/nonexist"))
 
-        self.assertFalse(self.store.has_frames('/queue/nonexist'))
-        self.assertEqual(self.store.size('/queue/nonexist'), 0)
+        self.assertFalse(self.store.has_frames("/queue/nonexist"))
+        self.assertEqual(self.store.size("/queue/nonexist"), 0)

--- a/tests/store/test_dbm.py
+++ b/tests/store/test_dbm.py
@@ -12,7 +12,6 @@ from coilmq.util import frames
 from coilmq.util.frames import Frame
 from tests.store import CommonQueueTest
 
-
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/store/test_dbm.py
+++ b/tests/store/test_dbm.py
@@ -1,4 +1,5 @@
 """Test DBM queue storage."""
+
 import shutil
 import tempfile
 import time
@@ -28,9 +29,8 @@ limitations under the License."""
 
 
 class DbmQueueTest(CommonQueueTest, unittest.TestCase):
-
     def setUp(self):
-        self.data_dir = tempfile.mkdtemp(prefix='coilmq-dbm-test')
+        self.data_dir = tempfile.mkdtemp(prefix="coilmq-dbm-test")
         self.store = DbmQueue(self.data_dir)
 
     def tearDown(self):
@@ -39,9 +39,10 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
 
     def test_dequeue_identity(self):
         """Test the dequeue() method."""
-        dest = '/queue/foo'
-        frame = Frame(frames.MESSAGE, headers={
-                      'message-id': str(uuid.uuid4())}, body='some data')
+        dest = "/queue/foo"
+        frame = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="some data"
+        )
         self.store.enqueue(dest, frame)
 
         self.assertTrue(self.store.has_frames(dest))
@@ -57,15 +58,18 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
     @pytest.mark.xfail(reason="https://github.com/hozn/coilmq/issues/41")
     def test_sync_checkpoint_ops(self):
         """Test a expected sync behavior with checkpoint_operations param."""
-        data_dir = tempfile.mkdtemp(prefix='coilmq-dbm-test')
+        data_dir = tempfile.mkdtemp(prefix="coilmq-dbm-test")
         max_ops = 5
         try:
             store = DbmQueue(data_dir, checkpoint_operations=max_ops)
-            dest = '/queue/foo'
+            dest = "/queue/foo"
 
             for i in range(max_ops + 1):
-                frame = Frame(frames.MESSAGE, headers={
-                              'message-id': str(uuid.uuid4())}, body=f'some data - {i}')
+                frame = Frame(
+                    frames.MESSAGE,
+                    headers={"message-id": str(uuid.uuid4())},
+                    body=f"some data - {i}",
+                )
                 store.enqueue(dest, frame)
 
             self.assertEqual(store.size(dest), max_ops + 1)
@@ -82,19 +86,25 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
     @pytest.mark.xfail(reason="https://github.com/hozn/coilmq/issues/41")
     def test_sync_checkpoint_timeout(self):
         """Test a expected sync behavior with checkpoint_timeout param."""
-        data_dir = tempfile.mkdtemp(prefix='coilmq-dbm-test')
+        data_dir = tempfile.mkdtemp(prefix="coilmq-dbm-test")
         try:
             store = DbmQueue(data_dir, checkpoint_timeout=0.5)
-            dest = '/queue/foo'
+            dest = "/queue/foo"
 
-            frame = Frame(frames.MESSAGE, headers={
-                          'message-id': str(uuid.uuid4())}, body='some data -1')
+            frame = Frame(
+                frames.MESSAGE,
+                headers={"message-id": str(uuid.uuid4())},
+                body="some data -1",
+            )
             store.enqueue(dest, frame)
 
             time.sleep(0.5)
 
-            frame = Frame(frames.MESSAGE, headers={
-                          'message-id': str(uuid.uuid4())}, body='some data -2')
+            frame = Frame(
+                frames.MESSAGE,
+                headers={"message-id": str(uuid.uuid4())},
+                body="some data -2",
+            )
             store.enqueue(dest, frame)
 
             self.assertEqual(store.size(dest), 2)
@@ -110,12 +120,15 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
 
     def test_sync_close(self):
         """Test a expected sync behavior of close() call."""
-        data_dir = tempfile.mkdtemp(prefix='coilmq-dbm-test')
+        data_dir = tempfile.mkdtemp(prefix="coilmq-dbm-test")
         try:
             store = DbmQueue(data_dir)
-            dest = '/queue/foo'
-            frame = Frame(frames.MESSAGE, headers={
-                          'message-id': str(uuid.uuid4())}, body='some data')
+            dest = "/queue/foo"
+            frame = Frame(
+                frames.MESSAGE,
+                headers={"message-id": str(uuid.uuid4())},
+                body="some data",
+            )
             store.enqueue(dest, frame)
             self.assertEqual(store.size(dest), 1)
 
@@ -131,12 +144,15 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
     @pytest.mark.xfail(reason="https://github.com/hozn/coilmq/issues/41")
     def test_sync_loss(self):
         """Test metadata loss behavior."""
-        data_dir = tempfile.mkdtemp(prefix='coilmq-dbm-test')
+        data_dir = tempfile.mkdtemp(prefix="coilmq-dbm-test")
         try:
             store = DbmQueue(data_dir)
-            dest = '/queue/foo'
-            frame = Frame(frames.MESSAGE, headers={
-                          'message-id': str(uuid.uuid4())}, body='some data')
+            dest = "/queue/foo"
+            frame = Frame(
+                frames.MESSAGE,
+                headers={"message-id": str(uuid.uuid4())},
+                body="some data",
+            )
             store.enqueue(dest, frame)
             self.assertEqual(store.size(dest), 1)
 

--- a/tests/store/test_memory.py
+++ b/tests/store/test_memory.py
@@ -1,4 +1,5 @@
 """Test memory queue storage."""
+
 import unittest
 import uuid
 
@@ -23,15 +24,15 @@ limitations under the License."""
 
 
 class MemoryQueueTest(CommonQueueTest, unittest.TestCase):
-
     def setUp(self):
         self.store = MemoryQueue()
 
     def test_dequeue_identity(self):
         """Test the dequeue() method."""
-        dest = '/queue/foo'
-        frame = Frame(frames.MESSAGE, headers={
-                      'message-id': str(uuid.uuid4())}, body='some data')
+        dest = "/queue/foo"
+        frame = Frame(
+            frames.MESSAGE, headers={"message-id": str(uuid.uuid4())}, body="some data"
+        )
         self.store.enqueue(dest, frame)
 
         self.assertTrue(self.store.has_frames(dest))

--- a/tests/store/test_redis_store.py
+++ b/tests/store/test_redis_store.py
@@ -9,21 +9,18 @@ from tests.store import CommonQueueTest
 
 
 class RedisStoreTestCase(CommonQueueTest, unittest.TestCase):
-
     def setUp(self):
         self.store = RedisQueueStore(redis_conn=fakeredis.FakeStrictRedis())
 
 
-@mock.patch('coilmq.store.rds.redis.Redis', fakeredis.FakeStrictRedis)
+@mock.patch("coilmq.store.rds.redis.Redis", fakeredis.FakeStrictRedis)
 class RedisStoreFactoryTestCase(unittest.TestCase):
     def test_from_config(self):
 
         config = ConfigParser()
-        config.add_section('redis')
-        config.set('redis', 'host', value='localhost')
-        config.set('redis', 'port', value='28222')
+        config.add_section("redis")
+        config.set("redis", "host", value="localhost")
+        config.set("redis", "port", value="28222")
 
         store = make_redis_store(cfg=config)
         self.assertIsInstance(store, RedisQueueStore)
-
-

--- a/tests/store/test_redis_store.py
+++ b/tests/store/test_redis_store.py
@@ -1,12 +1,11 @@
 import unittest
-
-import fakeredis
 from configparser import ConfigParser
 from unittest import mock
 
+import fakeredis
 
-from tests.store import CommonQueueTest
 from coilmq.store.rds import RedisQueueStore, make_redis_store
+from tests.store import CommonQueueTest
 
 
 class RedisStoreTestCase(CommonQueueTest, unittest.TestCase):

--- a/tests/store/test_sa.py
+++ b/tests/store/test_sa.py
@@ -1,4 +1,5 @@
 """Test SQLAlchemy storage."""
+
 import datetime
 import unittest
 
@@ -25,9 +26,8 @@ limitations under the License."""
 
 
 class SAQueueTest(CommonQueueTest, unittest.TestCase):
-
     def setUp(self):
-        engine = create_engine('sqlite:///:memory:', echo=True)
+        engine = create_engine("sqlite:///:memory:", echo=True)
         init_model(engine)
         self.store = SAQueue()
 
@@ -36,18 +36,15 @@ class SAQueueTest(CommonQueueTest, unittest.TestCase):
 
     def test_dequeue_order(self):
         """Test the order that frames are returned by dequeue() method."""
-        dest = '/queue/foo'
+        dest = "/queue/foo"
 
-        frame1 = Frame(frames.MESSAGE, headers={
-                       'message-id': 'id-1'}, body='message-1')
+        frame1 = Frame(frames.MESSAGE, headers={"message-id": "id-1"}, body="message-1")
         self.store.enqueue(dest, frame1)
 
-        frame2 = Frame(frames.MESSAGE, headers={
-                       'message-id': 'id-2'}, body='message-2')
+        frame2 = Frame(frames.MESSAGE, headers={"message-id": "id-2"}, body="message-2")
         self.store.enqueue(dest, frame2)
 
-        frame3 = Frame(frames.MESSAGE, headers={
-                       'message-id': 'id-3'}, body='message-3')
+        frame3 = Frame(frames.MESSAGE, headers={"message-id": "id-3"}, body="message-3")
         self.store.enqueue(dest, frame3)
 
         self.assertTrue(self.store.has_frames(dest))
@@ -56,12 +53,24 @@ class SAQueueTest(CommonQueueTest, unittest.TestCase):
         # Perform some updates to change the expected order.
 
         sess = meta.Session()
-        sess.execute(model.frames_table.update().where(
-            model.frames_table.c.message_id == 'id-1').values(queued=datetime.datetime(2010, 1, 1)))
-        sess.execute(model.frames_table.update().where(
-            model.frames_table.c.message_id == 'id-2').values(queued=datetime.datetime(2009, 1, 1)))
-        sess.execute(model.frames_table.update().where(
-            model.frames_table.c.message_id == 'id-3').values(queued=datetime.datetime(2004, 1, 1)))
+        sess.execute(
+            model.frames_table
+            .update()
+            .where(model.frames_table.c.message_id == "id-1")
+            .values(queued=datetime.datetime(2010, 1, 1))
+        )
+        sess.execute(
+            model.frames_table
+            .update()
+            .where(model.frames_table.c.message_id == "id-2")
+            .values(queued=datetime.datetime(2009, 1, 1))
+        )
+        sess.execute(
+            model.frames_table
+            .update()
+            .where(model.frames_table.c.message_id == "id-3")
+            .values(queued=datetime.datetime(2004, 1, 1))
+        )
         sess.commit()
 
         rframe1 = self.store.dequeue(dest)

--- a/tests/store/test_sa.py
+++ b/tests/store/test_sa.py
@@ -4,9 +4,7 @@ import unittest
 
 from sqlalchemy import create_engine
 
-from coilmq.store.sa import SAQueue
-from coilmq.store.sa import init_model
-from coilmq.store.sa import meta, model
+from coilmq.store.sa import SAQueue, init_model, meta, model
 from coilmq.util import frames
 from coilmq.util.frames import Frame
 from tests.store import CommonQueueTest

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 """Tests for authenticators."""
+
 import unittest
 
 try:
@@ -25,7 +26,6 @@ limitations under the License."""
 
 
 class SimpleAuthenticatorTest(unittest.TestCase):
-
     def setUp(self):
         pass
 
@@ -34,36 +34,38 @@ class SimpleAuthenticatorTest(unittest.TestCase):
 
     def test_constructor(self):
         """Test the with passing auth store in constructor."""
-        auth = SimpleAuthenticator({'user': 'pass'})
-        assert auth.authenticate('user', 'pass') == True
-        assert auth.authenticate('user1', 'pass') == False
-        assert auth.authenticate('user', 'pass2') == False
+        auth = SimpleAuthenticator({"user": "pass"})
+        assert auth.authenticate("user", "pass") == True
+        assert auth.authenticate("user1", "pass") == False
+        assert auth.authenticate("user", "pass2") == False
 
     def test_from_configfile(self):
         """Test the loading store from config file path."""
         auth = SimpleAuthenticator()
-        with as_file(files('tests.resources').joinpath('auth.ini')) as filename:
+        with as_file(files("tests.resources").joinpath("auth.ini")) as filename:
             auth.from_configfile(filename)
-        assert auth.authenticate('juniper', 'b3rr1es') == True
-        assert auth.authenticate('oak', 'ac$rrubrum') == True
-        assert auth.authenticate('pinetree', 'str0bus') == True
-        assert auth.authenticate('foo', 'bar') == False
+        assert auth.authenticate("juniper", "b3rr1es") == True
+        assert auth.authenticate("oak", "ac$rrubrum") == True
+        assert auth.authenticate("pinetree", "str0bus") == True
+        assert auth.authenticate("foo", "bar") == False
 
     def test_from_configfile_fp(self):
         """Test loading store from file-like object."""
         auth = SimpleAuthenticator()
-        with as_file(files('tests.resources').joinpath('auth.ini')) as filename, filename.open() as fp:
+        with as_file(
+            files("tests.resources").joinpath("auth.ini")
+        ) as filename, filename.open() as fp:
             auth.from_configfile(fp)
 
-        assert auth.authenticate('juniper', 'b3rr1es') == True
-        assert auth.authenticate('oak', 'ac$rrubrum') == True
-        assert auth.authenticate('pinetree', 'str0bus') == True
-        assert auth.authenticate('foo', 'bar') == False
+        assert auth.authenticate("juniper", "b3rr1es") == True
+        assert auth.authenticate("oak", "ac$rrubrum") == True
+        assert auth.authenticate("pinetree", "str0bus") == True
+        assert auth.authenticate("foo", "bar") == False
 
     def test_from_configfile_invalid(self):
         """Test loading store with invalid file path."""
         auth = SimpleAuthenticator()
-        with as_file(files('tests.resources').joinpath('auth-invalid.ini')) as filename:
+        with as_file(files("tests.resources").joinpath("auth-invalid.ini")) as filename:
             try:
                 auth.from_configfile(filename)
                 self.fail("Expected error with invalid filename.")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,6 @@
 """Tests for authenticators."""
-import os
 import unittest
+
 try:
     from importlib.resources import as_file, files
 except ImportError:
@@ -52,9 +52,8 @@ class SimpleAuthenticatorTest(unittest.TestCase):
     def test_from_configfile_fp(self):
         """Test loading store from file-like object."""
         auth = SimpleAuthenticator()
-        with as_file(files('tests.resources').joinpath('auth.ini')) as filename:
-            with filename.open() as fp:
-                auth.from_configfile(fp)
+        with as_file(files('tests.resources').joinpath('auth.ini')) as filename, filename.open() as fp:
+            auth.from_configfile(fp)
 
         assert auth.authenticate('juniper', 'b3rr1es') == True
         assert auth.authenticate('oak', 'ac$rrubrum') == True

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,4 +1,5 @@
 """Test the FrameBuffer utility class."""
+
 import io
 import unittest
 import uuid
@@ -46,7 +47,8 @@ class TestFrameBuffer(unittest.TestCase):
         """Test extracting a single frame."""
         sb = FrameBuffer()
         m1 = self.createMessage(
-            frames.CONNECT, {'session': uuid.uuid4()}, 'This is the body')
+            frames.CONNECT, {"session": uuid.uuid4()}, "This is the body"
+        )
         sb.append(m1)
         msg = sb.extract_frame()
         self.assertIsInstance(msg, Frame)
@@ -56,8 +58,11 @@ class TestFrameBuffer(unittest.TestCase):
         """Test extracting a binary frame."""
         sb = FrameBuffer()
         binmsg = "\x00\x00HELLO\x00\x00DONKEY\x00\x00"
-        m1 = self.createMessage(frames.SEND, OrderedDict({'content-length': len(binmsg), 'x-other-header': 'value'}), binmsg
-                                )
+        m1 = self.createMessage(
+            frames.SEND,
+            OrderedDict({"content-length": len(binmsg), "x-other-header": "value"}),
+            binmsg,
+        )
         sb.append(m1)
         msg = sb.extract_frame()
         self.assertIsInstance(msg, Frame)
@@ -65,14 +70,14 @@ class TestFrameBuffer(unittest.TestCase):
 
     def test_extract_frame_multi(self):
         """Test the handling of multiple concatenated messages by the buffer."""
-        m1 = b'CONNECT\nsession:207567f3-cce7-4a0a-930b-46fc394dd53d\n\n0123456789\x00'
-        m2 = b'SUBSCRIBE\nack:auto\ndestination:/queue/test\n\n\x00SEND\ndestination:/queue/test\n\n\x00'
+        m1 = b"CONNECT\nsession:207567f3-cce7-4a0a-930b-46fc394dd53d\n\n0123456789\x00"
+        m2 = b"SUBSCRIBE\nack:auto\ndestination:/queue/test\n\n\x00SEND\ndestination:/queue/test\n\n\x00"
 
         sb = FrameBuffer()
         sb.append(m1)
         f1 = sb.extract_frame()
         self.assertEqual(f1.cmd, frames.CONNECT)
-        self.assertEqual(f1.body, b'0123456789')
+        self.assertEqual(f1.body, b"0123456789")
 
         f = sb.extract_frame()
 
@@ -83,10 +88,10 @@ class TestFrameBuffer(unittest.TestCase):
         f3 = sb.extract_frame()
 
         self.assertEqual(f2.cmd, frames.SUBSCRIBE)
-        self.assertEqual(f2.body, '')
+        self.assertEqual(f2.body, "")
         self.assertEqual(f3.cmd, frames.SEND)
-        self.assertEqual(f3.headers.get('destination'), '/queue/test')
-        self.assertEqual(f3.body, '')
+        self.assertEqual(f3.headers.get("destination"), "/queue/test")
+        self.assertEqual(f3.body, "")
 
         self.assertIsNone(sb.extract_frame())
 
@@ -94,9 +99,11 @@ class TestFrameBuffer(unittest.TestCase):
         """Test the iteration feature of our buffer."""
         sb = FrameBuffer()
         m1 = self.createMessage(
-            frames.CONNECT, {'session': uuid.uuid4()}, b'This is the body')
+            frames.CONNECT, {"session": uuid.uuid4()}, b"This is the body"
+        )
         m2 = self.createMessage(
-            frames.SEND, {'destination': '/queue/sample'}, b'This is the body-2')
+            frames.SEND, {"destination": "/queue/sample"}, b"This is the body-2"
+        )
         sb.append(m1)
         sb.append(m2)
 
@@ -113,41 +120,44 @@ class TestFrameBuffer(unittest.TestCase):
 
 
 class FrameTestCase(unittest.TestCase):
-
     def test_parse_frame(self):
         buff = io.BytesIO(
-            b'CONNECT\nsession:207567f3-cce7-4a0a-930b-46fc394dd53d\n\n0123456789\x00')
+            b"CONNECT\nsession:207567f3-cce7-4a0a-930b-46fc394dd53d\n\n0123456789\x00"
+        )
         cmd, headers = parse_headers(buff)
         parse_body(buff, headers)
 
         self.assertIsInstance(cmd, str)
         self.assertEqual(cmd, frames.CONNECT)
-        self.assertEqual(headers['session'],
-                         '207567f3-cce7-4a0a-930b-46fc394dd53d')
+        self.assertEqual(headers["session"], "207567f3-cce7-4a0a-930b-46fc394dd53d")
 
         for e in [cmd] + list(headers.keys()) + list(headers.values()):
             self.assertIsInstance(e, str)
 
     def test_parse_frame_incomplete_body(self):
-        buff = io.BytesIO(b'CONNECT\ncontent-length:1000\n\n0123456789\x00')
+        buff = io.BytesIO(b"CONNECT\ncontent-length:1000\n\n0123456789\x00")
         self.assertRaises(IncompleteFrame, lambda: Frame.from_buffer(buff))
 
     def test_parse_frame_body_not_terminated(self):
-        buff = io.BytesIO(b'CONNECT\ncontent-length:10\n\n0123456789')
+        buff = io.BytesIO(b"CONNECT\ncontent-length:10\n\n0123456789")
         self.assertRaises(BodyNotTerminated, lambda: Frame.from_buffer(buff))
 
     def test_parse_frame_empty_body(self):
         buff = io.BytesIO(
-            b'SUBSCRIBE\nack:auto\ndestination:/queue/test\n\n\x00fdffdfd')
+            b"SUBSCRIBE\nack:auto\ndestination:/queue/test\n\n\x00fdffdfd"
+        )
         Frame.from_buffer(buff)
 
     def test_pack(self):
-        frame = Frame(frames.CONNECT, OrderedDict(foo='bar'), 'body')
+        frame = Frame(frames.CONNECT, OrderedDict(foo="bar"), "body")
         self.assertEqual(
-            frame.pack(), b'CONNECT\nfoo:bar\ncontent-length:4\n\nbody\x00')
+            frame.pack(), b"CONNECT\nfoo:bar\ncontent-length:4\n\nbody\x00"
+        )
 
     def test_pack_binary(self):
         bin_body = "\x00\x00HELLO\x00\x00DONKEY\x00\x00"
         frame = Frame(frames.CONNECT, body=bin_body)
-        self.assertEqual(frame.pack(
-        ), b'CONNECT\ncontent-length:17\n\n\x00\x00HELLO\x00\x00DONKEY\x00\x00\x00')
+        self.assertEqual(
+            frame.pack(),
+            b"CONNECT\ncontent-length:17\n\n\x00\x00HELLO\x00\x00DONKEY\x00\x00\x00",
+        )

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,12 +1,18 @@
 """Test the FrameBuffer utility class."""
+import io
 import unittest
 import uuid
-import io
-import zlib
 from collections import OrderedDict
 
-from coilmq.util.frames import Frame, FrameBuffer, parse_headers, parse_body, IncompleteFrame, BodyNotTerminated
 from coilmq.util import frames
+from coilmq.util.frames import (
+    BodyNotTerminated,
+    Frame,
+    FrameBuffer,
+    IncompleteFrame,
+    parse_body,
+    parse_headers,
+)
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2010 Hans Lellelid"
@@ -112,7 +118,7 @@ class FrameTestCase(unittest.TestCase):
         buff = io.BytesIO(
             b'CONNECT\nsession:207567f3-cce7-4a0a-930b-46fc394dd53d\n\n0123456789\x00')
         cmd, headers = parse_headers(buff)
-        body = parse_body(buff, headers)
+        parse_body(buff, headers)
 
         self.assertIsInstance(cmd, str)
         self.assertEqual(cmd, frames.CONNECT)
@@ -133,7 +139,7 @@ class FrameTestCase(unittest.TestCase):
     def test_parse_frame_empty_body(self):
         buff = io.BytesIO(
             b'SUBSCRIBE\nack:auto\ndestination:/queue/test\n\n\x00fdffdfd')
-        f = Frame.from_buffer(buff)
+        Frame.from_buffer(buff)
 
     def test_pack(self):
         frame = Frame(frames.CONNECT, OrderedDict(foo='bar'), 'body')

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,4 +1,5 @@
 """Tests for the transport-agnostic engine module."""
+
 import unittest
 
 from coilmq.engine import StompEngine
@@ -27,16 +28,17 @@ limitations under the License."""
 
 
 class EngineTest(unittest.TestCase):
-
     def setUp(self):
         self.qm = MockQueueManager()
         self.tm = MockTopicManager()
         self.conn = MockConnection()
         self.auth = MockAuthenticator()
-        self.engine = StompEngine(connection=self.conn,
-                                  queue_manager=self.qm,
-                                  topic_manager=self.tm,
-                                  authenticator=None)
+        self.engine = StompEngine(
+            connection=self.conn,
+            queue_manager=self.qm,
+            topic_manager=self.tm,
+            authenticator=None,
+        )
 
     def tearDown(self):
         self.conn.reset()
@@ -50,7 +52,7 @@ class EngineTest(unittest.TestCase):
         string.
         """
         assert frame.cmd == frames.ERROR
-        assert msgsub.lower() in frame.headers['message'].lower()
+        assert msgsub.lower() in frame.headers["message"].lower()
 
     def test_connect_no_auth(self):
         """Test the CONNECT command with no auth required."""
@@ -64,118 +66,152 @@ class EngineTest(unittest.TestCase):
 
         assert self.engine.connected == False
         self.engine.process_frame(Frame(frames.CONNECT))
-        self.assertErrorFrame(self.conn.frames[-1], 'Auth')
+        self.assertErrorFrame(self.conn.frames[-1], "Auth")
         assert self.engine.connected == False
 
-        self.engine.process_frame(Frame(frames.CONNECT, headers={'login': MockAuthenticator.LOGIN,
-                                                            'passcode': MockAuthenticator.PASSCODE}))
+        self.engine.process_frame(
+            Frame(
+                frames.CONNECT,
+                headers={
+                    "login": MockAuthenticator.LOGIN,
+                    "passcode": MockAuthenticator.PASSCODE,
+                },
+            )
+        )
         assert self.engine.connected == True
 
     def test_subscribe_noack(self):
         """Test subscribing to topics and queues w/ no ACK."""
         self._connect()
         self.engine.process_frame(
-            Frame(frames.SUBSCRIBE, headers={'destination': '/queue/bar'}))
-        assert self.conn in self.qm.queues['/queue/bar']
+            Frame(frames.SUBSCRIBE, headers={"destination": "/queue/bar"})
+        )
+        assert self.conn in self.qm.queues["/queue/bar"]
 
         self.engine.process_frame(
-            Frame(frames.SUBSCRIBE, headers={'destination': '/foo/bar'}))
-        assert self.conn in self.tm.topics['/foo/bar']
+            Frame(frames.SUBSCRIBE, headers={"destination": "/foo/bar"})
+        )
+        assert self.conn in self.tm.topics["/foo/bar"]
 
     def test_send(self):
         """Test sending to a topic and queue."""
         self._connect()
 
-        msg = Frame(frames.SEND, headers={
-                    'destination': '/queue/foo'}, body='QUEUEMSG-BODY')
+        msg = Frame(
+            frames.SEND, headers={"destination": "/queue/foo"}, body="QUEUEMSG-BODY"
+        )
         self.engine.process_frame(msg)
         self.assertEqual(msg, self.qm.messages[-1])
 
-        msg = Frame(frames.SEND, headers={
-                    'destination': '/topic/foo'}, body='TOPICMSG-BODY')
+        msg = Frame(
+            frames.SEND, headers={"destination": "/topic/foo"}, body="TOPICMSG-BODY"
+        )
         self.engine.process_frame(msg)
         self.assertEqual(msg, self.tm.messages[-1])
 
-        msg = Frame(frames.SEND, headers={}, body='TOPICMSG-BODY')
+        msg = Frame(frames.SEND, headers={}, body="TOPICMSG-BODY")
         self.engine.process_frame(msg)
-        self.assertErrorFrame(self.conn.frames[-1], 'Missing destination')
+        self.assertErrorFrame(self.conn.frames[-1], "Missing destination")
 
     def test_receipt(self):
         """Test pushing frames with a receipt specified."""
         self._connect()
 
-        receipt_id = 'FOOBAR'
-        msg = Frame(frames.SEND, headers={
-                    'destination': '/queue/foo', 'receipt': receipt_id}, body='QUEUEMSG-BODY')
+        receipt_id = "FOOBAR"
+        msg = Frame(
+            frames.SEND,
+            headers={"destination": "/queue/foo", "receipt": receipt_id},
+            body="QUEUEMSG-BODY",
+        )
         self.engine.process_frame(msg)
         rframe = self.conn.frames[-1]
         self.assertIsInstance(rframe, ReceiptFrame)
-        self.assertEqual(receipt_id, rframe.headers.get('receipt-id'))
+        self.assertEqual(receipt_id, rframe.headers.get("receipt-id"))
 
-        receipt_id = 'FOOBAR2'
-        self.engine.process_frame(Frame(frames.SUBSCRIBE, headers={
-                                  'destination': '/queue/bar', 'receipt': receipt_id}))
+        receipt_id = "FOOBAR2"
+        self.engine.process_frame(
+            Frame(
+                frames.SUBSCRIBE,
+                headers={"destination": "/queue/bar", "receipt": receipt_id},
+            )
+        )
         rframe = self.conn.frames[-1]
         self.assertIsInstance(rframe, ReceiptFrame)
-        self.assertEqual(receipt_id, rframe.headers.get('receipt-id'))
+        self.assertEqual(receipt_id, rframe.headers.get("receipt-id"))
 
     def test_subscribe_ack(self):
         """Test subscribing to a queue with ack=true."""
         self._connect()
-        self.engine.process_frame(Frame(frames.SUBSCRIBE, headers={'destination': '/queue/bar',
-                                                              'ack': 'client'}))
+        self.engine.process_frame(
+            Frame(
+                frames.SUBSCRIBE, headers={"destination": "/queue/bar", "ack": "client"}
+            )
+        )
         assert self.conn.reliable_subscriber == True
-        assert self.conn in self.qm.queues['/queue/bar']
+        assert self.conn in self.qm.queues["/queue/bar"]
 
     def test_unsubscribe(self):
         """Test the UNSUBSCRIBE command."""
         self._connect()
         self.engine.process_frame(
-            Frame(frames.SUBSCRIBE, headers={'destination': '/queue/bar'}))
-        assert self.conn in self.qm.queues['/queue/bar']
+            Frame(frames.SUBSCRIBE, headers={"destination": "/queue/bar"})
+        )
+        assert self.conn in self.qm.queues["/queue/bar"]
 
         self.engine.process_frame(
-            Frame(frames.UNSUBSCRIBE, headers={'destination': '/queue/bar'}))
-        assert self.conn not in self.qm.queues['/queue/bar']
+            Frame(frames.UNSUBSCRIBE, headers={"destination": "/queue/bar"})
+        )
+        assert self.conn not in self.qm.queues["/queue/bar"]
 
         self.engine.process_frame(
-            Frame(frames.UNSUBSCRIBE, headers={'destination': '/invalid'}))
+            Frame(frames.UNSUBSCRIBE, headers={"destination": "/invalid"})
+        )
 
     def test_begin(self):
         """Test transaction BEGIN."""
         self._connect()
 
-        self.engine.process_frame(
-            Frame(frames.BEGIN, headers={'transaction': 'abc'}))
-        assert 'abc' in self.engine.transactions
-        assert len(self.engine.transactions['abc']) == 0
+        self.engine.process_frame(Frame(frames.BEGIN, headers={"transaction": "abc"}))
+        assert "abc" in self.engine.transactions
+        assert len(self.engine.transactions["abc"]) == 0
 
     def test_commit(self):
         """Test transaction COMMIT."""
         self._connect()
 
+        self.engine.process_frame(Frame(frames.BEGIN, headers={"transaction": "abc"}))
+        self.engine.process_frame(Frame(frames.BEGIN, headers={"transaction": "123"}))
         self.engine.process_frame(
-            Frame(frames.BEGIN, headers={'transaction': 'abc'}))
+            Frame(
+                frames.SEND,
+                headers={"destination": "/dest", "transaction": "abc"},
+                body="ASDF",
+            )
+        )
         self.engine.process_frame(
-            Frame(frames.BEGIN, headers={'transaction': '123'}))
-        self.engine.process_frame(Frame(
-            frames.SEND, headers={'destination': '/dest', 'transaction': 'abc'}, body='ASDF'))
-        self.engine.process_frame(Frame(
-            frames.SEND, headers={'destination': '/dest', 'transaction': 'abc'}, body='ASDF'))
-        self.engine.process_frame(Frame(
-            frames.SEND, headers={'destination': '/dest', 'transaction': '123'}, body='ASDF'))
+            Frame(
+                frames.SEND,
+                headers={"destination": "/dest", "transaction": "abc"},
+                body="ASDF",
+            )
+        )
+        self.engine.process_frame(
+            Frame(
+                frames.SEND,
+                headers={"destination": "/dest", "transaction": "123"},
+                body="ASDF",
+            )
+        )
 
         assert len(self.tm.messages) == 0
 
-        self.engine.process_frame(
-            Frame(frames.COMMIT, headers={'transaction': 'abc'}))
+        self.engine.process_frame(Frame(frames.COMMIT, headers={"transaction": "abc"}))
 
         assert len(self.tm.messages) == 2
 
         assert len(self.engine.transactions) == 1
 
-        self.engine.process_frame(
-            Frame(frames.COMMIT, headers={'transaction': '123'}))
+        self.engine.process_frame(Frame(frames.COMMIT, headers={"transaction": "123"}))
         assert len(self.tm.messages) == 3
 
         assert len(self.engine.transactions) == 0
@@ -185,50 +221,60 @@ class EngineTest(unittest.TestCase):
         self._connect()
 
         # Send a message with invalid transaction
-        f = Frame(frames.SEND, headers={
-                  'destination': '/dest', 'transaction': '123'}, body='ASDF')
+        f = Frame(
+            frames.SEND,
+            headers={"destination": "/dest", "transaction": "123"},
+            body="ASDF",
+        )
         self.engine.process_frame(f)
-        self.assertErrorFrame(self.conn.frames[-1], 'invalid transaction')
+        self.assertErrorFrame(self.conn.frames[-1], "invalid transaction")
 
         # Attempt to commit invalid transaction
-        self.engine.process_frame(
-            Frame(frames.COMMIT, headers={'transaction': 'abc'}))
+        self.engine.process_frame(Frame(frames.COMMIT, headers={"transaction": "abc"}))
 
         # Attempt to commit already-committed transaction
+        self.engine.process_frame(Frame(frames.BEGIN, headers={"transaction": "abc"}))
         self.engine.process_frame(
-            Frame(frames.BEGIN, headers={'transaction': 'abc'}))
-        self.engine.process_frame(Frame(
-            frames.SEND, headers={'destination': '/dest', 'transaction': 'abc'}, body='FOO'))
-        self.engine.process_frame(
-            Frame(frames.COMMIT, headers={'transaction': 'abc'}))
+            Frame(
+                frames.SEND,
+                headers={"destination": "/dest", "transaction": "abc"},
+                body="FOO",
+            )
+        )
+        self.engine.process_frame(Frame(frames.COMMIT, headers={"transaction": "abc"}))
 
-        self.engine.process_frame(
-            Frame(frames.COMMIT, headers={'transaction': 'abc'}))
-        self.assertErrorFrame(self.conn.frames[-1], 'invalid transaction')
+        self.engine.process_frame(Frame(frames.COMMIT, headers={"transaction": "abc"}))
+        self.assertErrorFrame(self.conn.frames[-1], "invalid transaction")
 
     def test_abort(self):
         """Test transaction ABORT."""
         self._connect()
 
-        self.engine.process_frame(
-            Frame(frames.BEGIN, headers={'transaction': 'abc'}))
-        self.engine.process_frame(
-            Frame(frames.BEGIN, headers={'transaction': '123'}))
+        self.engine.process_frame(Frame(frames.BEGIN, headers={"transaction": "abc"}))
+        self.engine.process_frame(Frame(frames.BEGIN, headers={"transaction": "123"}))
 
-        f1 = Frame(frames.SEND, headers={
-                   'destination': '/dest', 'transaction': 'abc'}, body='ASDF')
+        f1 = Frame(
+            frames.SEND,
+            headers={"destination": "/dest", "transaction": "abc"},
+            body="ASDF",
+        )
         self.engine.process_frame(f1)
-        f2 = Frame(frames.SEND, headers={
-                   'destination': '/dest', 'transaction': 'abc'}, body='ASDF')
+        f2 = Frame(
+            frames.SEND,
+            headers={"destination": "/dest", "transaction": "abc"},
+            body="ASDF",
+        )
         self.engine.process_frame(f2)
-        f3 = Frame(frames.SEND, headers={
-                   'destination': '/dest', 'transaction': '123'}, body='ASDF')
+        f3 = Frame(
+            frames.SEND,
+            headers={"destination": "/dest", "transaction": "123"},
+            body="ASDF",
+        )
         self.engine.process_frame(f3)
 
         assert len(self.tm.messages) == 0
 
-        self.engine.process_frame(
-            Frame(frames.ABORT, headers={'transaction': 'abc'}))
+        self.engine.process_frame(Frame(frames.ABORT, headers={"transaction": "abc"}))
         assert len(self.tm.messages) == 0
 
         assert len(self.engine.transactions) == 1
@@ -237,16 +283,12 @@ class EngineTest(unittest.TestCase):
         """Test invalid states for transaction ABORT."""
         self._connect()
 
-        self.engine.process_frame(
-            Frame(frames.ABORT, headers={'transaction': 'abc'}))
+        self.engine.process_frame(Frame(frames.ABORT, headers={"transaction": "abc"}))
 
-        self.assertErrorFrame(self.conn.frames[-1], 'invalid transaction')
+        self.assertErrorFrame(self.conn.frames[-1], "invalid transaction")
 
-        self.engine.process_frame(
-            Frame(frames.BEGIN, headers={'transaction': 'abc'}))
-        self.engine.process_frame(
-            Frame(frames.ABORT, headers={'transaction': 'abc'}))
+        self.engine.process_frame(Frame(frames.BEGIN, headers={"transaction": "abc"}))
+        self.engine.process_frame(Frame(frames.ABORT, headers={"transaction": "abc"}))
 
-        self.engine.process_frame(
-            Frame(frames.ABORT, headers={'transaction': 'abc2'}))
-        self.assertErrorFrame(self.conn.frames[-1], 'invalid transaction')
+        self.engine.process_frame(Frame(frames.ABORT, headers={"transaction": "abc2"}))
+        self.assertErrorFrame(self.conn.frames[-1], "invalid transaction")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,7 +4,12 @@ import unittest
 from coilmq.engine import StompEngine
 from coilmq.util import frames
 from coilmq.util.frames import Frame, ReceiptFrame
-from tests.mock import (MockAuthenticator, MockConnection, MockQueueManager, MockTopicManager)
+from tests.mock import (
+    MockAuthenticator,
+    MockConnection,
+    MockQueueManager,
+    MockTopicManager,
+)
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
 __copyright__ = "Copyright 2009 Hans Lellelid"

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,4 +1,5 @@
 """Tests for queue-related classes."""
+
 import unittest
 import uuid
 
@@ -41,18 +42,18 @@ class QueueManagerTest(unittest.TestCase):
         self.conn = MockConnection()
 
     def test_frames_iterator(self):
-        dest = '/queue/dest'
-        f = Frame(frames.SEND, headers={'destination': dest}, body='Empty')
+        dest = "/queue/dest"
+        f = Frame(frames.SEND, headers={"destination": dest}, body="Empty")
         self.qm.send(f)
 
         self.assertTrue(bool(self.store.frames(dest)))
 
     def test_subscribe(self):
         """Test subscribing a connection to the queue."""
-        dest = '/queue/dest'
+        dest = "/queue/dest"
 
         self.qm.subscribe(self.conn, dest)
-        f = Frame(frames.MESSAGE, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.MESSAGE, headers={"destination": dest}, body="Empty")
         self.qm.send(f)
 
         self.assertEqual(len(self.conn.frames), 1)
@@ -60,17 +61,17 @@ class QueueManagerTest(unittest.TestCase):
 
     def test_unsubscribe(self):
         """Test unsubscribing a connection from the queue."""
-        dest = '/queue/dest'
+        dest = "/queue/dest"
 
         self.qm.subscribe(self.conn, dest)
-        f = Frame(frames.MESSAGE, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.MESSAGE, headers={"destination": dest}, body="Empty")
         self.qm.send(f)
 
         self.assertEqual(len(self.conn.frames), 1)
         self.assertEqual(self.conn.frames[0], f)
 
         self.qm.unsubscribe(self.conn, dest)
-        f = Frame(frames.MESSAGE, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.MESSAGE, headers={"destination": dest}, body="Empty")
         self.qm.send(f)
 
         self.assertEqual(len(self.conn.frames), 1)
@@ -78,16 +79,16 @@ class QueueManagerTest(unittest.TestCase):
 
     def test_send_simple(self):
         """Test a basic send command."""
-        dest = '/queue/dest'
+        dest = "/queue/dest"
 
-        f = Frame(frames.SEND, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.SEND, headers={"destination": dest}, body="Empty")
         self.qm.send(f)
 
         self.assertIn(dest, self.store.destinations())
         self.assertEqual(len(self.store.frames(dest)), 1)
 
         # Assert some side-effects
-        self.assertIn('message-id', f.headers)
+        self.assertIn("message-id", f.headers)
         self.assertEqual(f.cmd, frames.MESSAGE)
 
     def test_send_err(self):
@@ -99,13 +100,13 @@ class QueueManagerTest(unittest.TestCase):
             def send_frame(self, frame):
                 raise RuntimeError("Error sending data.")
 
-        dest = '/queue/dest'
+        dest = "/queue/dest"
 
         # This reliable subscriber will be chosen first
         conn = ExcThrowingConn()
         self.qm.subscribe(conn, dest)
 
-        f = Frame(frames.SEND, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.SEND, headers={"destination": dest}, body="Empty")
         try:
             self.qm.send(f)
             self.fail("Expected failure when there was an error sending.")
@@ -121,9 +122,9 @@ class QueueManagerTest(unittest.TestCase):
             def send_frame(self, frame):
                 raise RuntimeError("Error sending data.")
 
-        dest = '/queue/send-backlog-err-reliable'
+        dest = "/queue/send-backlog-err-reliable"
 
-        f = Frame(frames.SEND, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.SEND, headers={"destination": dest}, body="Empty")
         self.qm.send(f)
 
         conn = ExcThrowingConn()
@@ -152,12 +153,12 @@ class QueueManagerTest(unittest.TestCase):
             def send_frame(self, frame):
                 raise RuntimeError("Error sending data.")
 
-        dest = '/queue/dest'
+        dest = "/queue/dest"
 
-        f = Frame(frames.SEND, headers={'destination': dest}, body='123')
+        f = Frame(frames.SEND, headers={"destination": dest}, body="123")
         self.qm.send(f)
 
-        f2 = Frame(frames.SEND, headers={'destination': dest}, body='12345')
+        f2 = Frame(frames.SEND, headers={"destination": dest}, body="12345")
         self.qm.send(f2)
 
         conn = ExcThrowingConn()
@@ -185,7 +186,7 @@ class QueueManagerTest(unittest.TestCase):
         This is actually a test of the underlying scheduler more than it is a test
         of the send message, per se.
         """
-        dest = '/queue/dest'
+        dest = "/queue/dest"
         conn1 = MockConnection()
         conn1.reliable_subscriber = True
 
@@ -195,8 +196,11 @@ class QueueManagerTest(unittest.TestCase):
         conn2.reliable_subscriber = False
         self.qm.subscribe(conn2, dest)
 
-        f = Frame(frames.MESSAGE, headers={
-                  'destination': dest, 'message-id': uuid.uuid4()}, body='Empty')
+        f = Frame(
+            frames.MESSAGE,
+            headers={"destination": dest, "message-id": uuid.uuid4()},
+            body="Empty",
+        )
         self.qm.send(f)
 
         self.assertEqual(len(conn1.frames), 1)
@@ -204,10 +208,13 @@ class QueueManagerTest(unittest.TestCase):
 
     def test_clear_transaction_frames(self):
         """Test the clearing of transaction ACK frames."""
-        dest = '/queue/tx'
+        dest = "/queue/tx"
 
-        f = Frame(frames.SEND, headers={'destination': dest,
-                                   'transaction': '1'}, body='Body-A')
+        f = Frame(
+            frames.SEND,
+            headers={"destination": dest, "transaction": "1"},
+            body="Body-A",
+        )
         self.qm.send(f)
 
         self.assertIn(dest, self.store.destinations())
@@ -218,31 +225,35 @@ class QueueManagerTest(unittest.TestCase):
 
         self.assertEqual(len(conn1.frames), 1)
 
-        self.qm.clear_transaction_frames(conn1, '1')
+        self.qm.clear_transaction_frames(conn1, "1")
 
     def test_ack_basic(self):
         """Test reliable client (ACK) behavior."""
-        dest = '/queue/ack-basic'
+        dest = "/queue/ack-basic"
         conn1 = MockConnection()
         conn1.reliable_subscriber = True
 
         self.qm.subscribe(conn1, dest)
 
-        m1 = Frame(frames.MESSAGE, headers={
-                   'destination': dest}, body='Message body (1)')
+        m1 = Frame(
+            frames.MESSAGE, headers={"destination": dest}, body="Message body (1)"
+        )
         self.qm.send(m1)
 
         self.assertEqual(conn1.frames[0], m1)
 
-        m2 = Frame(frames.MESSAGE, headers={
-                   'destination': dest}, body='Message body (2)')
+        m2 = Frame(
+            frames.MESSAGE, headers={"destination": dest}, body="Message body (2)"
+        )
         self.qm.send(m2)
 
         self.assertEqual(len(conn1.frames), 1)
         self.assertEqual(conn1.frames[0], m1)
 
-        ack = Frame(frames.ACK, headers={'destination': dest,
-                                    'message-id': m1.headers['message-id']})
+        ack = Frame(
+            frames.ACK,
+            headers={"destination": dest, "message-id": m1.headers["message-id"]},
+        )
         self.qm.ack(conn1, ack)
 
         self.assertEqual(len(conn1.frames), 2, "Expected 2 frames now, after ACK.")
@@ -252,55 +263,73 @@ class QueueManagerTest(unittest.TestCase):
 
     def test_ack_transaction(self):
         """Test the reliable client (ACK) behavior with transactions."""
-        dest = '/queue/ack-transaction'
+        dest = "/queue/ack-transaction"
         conn1 = MockConnection()
         conn1.reliable_subscriber = True
 
         self.qm.subscribe(conn1, dest)
 
-        m1 = Frame(frames.MESSAGE, headers={
-                   'destination': dest, }, body='Message body (1)')
+        m1 = Frame(
+            frames.MESSAGE,
+            headers={
+                "destination": dest,
+            },
+            body="Message body (1)",
+        )
         self.qm.send(m1)
 
         assert conn1.frames[0] == m1
 
-        m2 = Frame(frames.MESSAGE, headers={
-                   'destination': dest}, body='Message body (2)')
+        m2 = Frame(
+            frames.MESSAGE, headers={"destination": dest}, body="Message body (2)"
+        )
         self.qm.send(m2)
 
-        assert len(
-            conn1.frames) == 1, "Expected connection to still only have 1 frame."
+        assert len(conn1.frames) == 1, "Expected connection to still only have 1 frame."
         assert conn1.frames[0] == m1
 
-        ack = Frame(frames.ACK, headers={
-                    'destination': dest, 'transaction': 'abc', 'message-id': m1.headers.get('message-id')})
-        self.qm.ack(conn1, ack, transaction='abc')
+        ack = Frame(
+            frames.ACK,
+            headers={
+                "destination": dest,
+                "transaction": "abc",
+                "message-id": m1.headers.get("message-id"),
+            },
+        )
+        self.qm.ack(conn1, ack, transaction="abc")
 
-        ack = Frame(frames.ACK, headers={
-                    'destination': dest, 'transaction': 'abc', 'message-id': m2.headers.get('message-id')})
-        self.qm.ack(conn1, ack, transaction='abc')
+        ack = Frame(
+            frames.ACK,
+            headers={
+                "destination": dest,
+                "transaction": "abc",
+                "message-id": m2.headers.get("message-id"),
+            },
+        )
+        self.qm.ack(conn1, ack, transaction="abc")
 
         self.assertEqual(len(conn1.frames), 2, "Expected 2 frames now, after ACK.")
         subscription = conn1.frames[1].headers.pop("subscription", None)
         self.assertEqual(subscription, 0)
-        self.assertEqual(conn1.frames[1],  m2)
+        self.assertEqual(conn1.frames[1], m2)
 
-        self.qm.resend_transaction_frames(conn1, transaction='abc')
+        self.qm.resend_transaction_frames(conn1, transaction="abc")
 
         self.assertEqual(len(conn1.frames), 3, "Expected 3 frames after re-transmit.")
         pending = {s for s in self.qm._pending if s.connection == conn1}
-        self.assertEqual(len(pending), 1, "Expected 1 pending (waiting on ACK) frame.""")
+        self.assertEqual(len(pending), 1, "Expected 1 pending (waiting on ACK) frame.")
 
     def test_disconnect_pending_frames(self):
         """Test a queue disconnect when there are pending frames."""
-        dest = '/queue/disconnect-pending-frames'
+        dest = "/queue/disconnect-pending-frames"
         conn1 = MockConnection()
         conn1.reliable_subscriber = True
 
         self.qm.subscribe(conn1, dest)
 
-        m1 = Frame(frames.MESSAGE, headers={
-                   'destination': dest}, body='Message body (1)')
+        m1 = Frame(
+            frames.MESSAGE, headers={"destination": dest}, body="Message body (1)"
+        )
         self.qm.send(m1)
 
         self.assertEqual(conn1.frames[0], m1)

--- a/tests/test_queue_dbm.py
+++ b/tests/test_queue_dbm.py
@@ -1,4 +1,5 @@
 """Test of the QueueManager when using a DBM backend (store)."""
+
 import os
 import os.path
 import shutil
@@ -31,13 +32,14 @@ class DBMQueueManagerTest(QueueManagerTest):
 
         :rtype: QueueStore
         """
-        data_dir = os.path.abspath(os.path.join('/tmp/coilmq-test', 'data'))
+        data_dir = os.path.abspath(os.path.join("/tmp/coilmq-test", "data"))
         if os.path.exists(data_dir):
             shutil.rmtree(data_dir)
         os.makedirs(data_dir)
 
         cp_ops = 100
         cp_timeout = 20
-        store = DbmQueue(data_dir, checkpoint_operations=cp_ops,
-                         checkpoint_timeout=cp_timeout)
+        store = DbmQueue(
+            data_dir, checkpoint_operations=cp_ops, checkpoint_timeout=cp_timeout
+        )
         return store

--- a/tests/test_queue_sa.py
+++ b/tests/test_queue_sa.py
@@ -1,4 +1,5 @@
 """Test of the QueueManager when using a SQLite (SQLAlchemy) backend (store)."""
+
 import os
 import os.path
 
@@ -32,11 +33,11 @@ class SAQueueManagerTest(QueueManagerTest):
 
         :rtype: QueueStore
         """
-        data_dir = os.path.join(os.getcwd(), 'data')
+        data_dir = os.path.join(os.getcwd(), "data")
         if not os.path.exists(data_dir):
             os.makedirs(data_dir)
 
-        configuration = {'qstore.sqlalchemy.url': 'sqlite:///data/coilmq.db'}
-        engine = engine_from_config(configuration, 'qstore.sqlalchemy.')
+        configuration = {"qstore.sqlalchemy.url": "sqlite:///data/coilmq.db"}
+        engine = engine_from_config(configuration, "qstore.sqlalchemy.")
         init_model(engine, drop=True)
         return SAQueue()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,5 @@
 """Tests for the scheduler implementation."""
+
 import unittest
 
 from coilmq.scheduler import FavorReliableSubscriberScheduler
@@ -34,5 +35,4 @@ class QueueDeliverySchedulerTest(unittest.TestCase):
 
         choice = sched.choice((sub1, sub2), None)
 
-        self.assertIs(
-            choice, sub1, "Expected reliable connection to be selected.")
+        self.assertIs(choice, sub1, "Expected reliable connection to be selected.")

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -5,7 +5,6 @@ from coilmq.start import server_from_config
 
 
 class GetServerTestCase(unittest.TestCase):
-
     def test_server_from_config_default(self):
 
         self.assertIsInstance(server_from_config(), ThreadedStompServer)

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -3,6 +3,7 @@ import unittest
 from coilmq.server.socket_server import ThreadedStompServer
 from coilmq.start import server_from_config
 
+
 class GetServerTestCase(unittest.TestCase):
 
     def test_server_from_config_default(self):

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,4 +1,5 @@
 """Tests for the subscription management."""
+
 import unittest
 
 from coilmq.subscription import SubscriptionManager

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -1,4 +1,5 @@
 """Tests for topic-related functionality."""
+
 import unittest
 
 from coilmq.topic import TopicManager
@@ -30,10 +31,10 @@ class TopicManagerTest(unittest.TestCase):
 
     def test_subscribe(self):
         """Test subscribing a connection to the topic."""
-        dest = '/topic/dest'
+        dest = "/topic/dest"
 
         self.tm.subscribe(self.conn, dest)
-        f = Frame(frames.MESSAGE, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.MESSAGE, headers={"destination": dest}, body="Empty")
         self.tm.send(f)
 
         self.assertEqual(len(self.conn.frames), 1)
@@ -43,10 +44,10 @@ class TopicManagerTest(unittest.TestCase):
 
     def test_unsubscribe(self):
         """Test unsubscribing a connection from the queue."""
-        dest = '/topic/dest'
+        dest = "/topic/dest"
 
         self.tm.subscribe(self.conn, dest)
-        f = Frame(frames.MESSAGE, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.MESSAGE, headers={"destination": dest}, body="Empty")
         self.tm.send(f)
 
         self.assertEqual(len(self.conn.frames), 1)
@@ -55,20 +56,20 @@ class TopicManagerTest(unittest.TestCase):
         self.assertEqual(self.conn.frames[0], f)
 
         self.tm.unsubscribe(self.conn, dest)
-        f = Frame(frames.MESSAGE, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.MESSAGE, headers={"destination": dest}, body="Empty")
         self.tm.send(f)
 
         self.assertEqual(len(self.conn.frames), 1)
 
     def test_send_simple(self):
         """Test a basic send command."""
-        dest = '/topic/dest'
+        dest = "/topic/dest"
 
-        f = Frame(frames.SEND, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.SEND, headers={"destination": dest}, body="Empty")
         self.tm.send(f)
 
         # Assert some side-effects
-        self.assertIn('message-id', f.headers)
+        self.assertIn("message-id", f.headers)
         self.assertEqual(f.cmd, frames.MESSAGE)
 
     def test_send_subscriber_timeout(self):
@@ -83,7 +84,7 @@ class TopicManagerTest(unittest.TestCase):
             def reset(self):
                 pass
 
-        dest = '/topic/dest'
+        dest = "/topic/dest"
 
         bad_client = TimeoutConnection()
 
@@ -91,7 +92,7 @@ class TopicManagerTest(unittest.TestCase):
         self.tm.subscribe(bad_client, dest)
         self.tm.subscribe(self.conn, dest)
 
-        f = Frame(frames.MESSAGE, headers={'destination': dest}, body='Empty')
+        f = Frame(frames.MESSAGE, headers={"destination": dest}, body="Empty")
         self.tm.send(f)
 
         # Make sure out good client got the message.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,10 +6,8 @@ from coilmq.util.concurrency import CoilThreadingTimer
 
 
 class CoilTimerTestCase(unittest.TestCase):
-
     def setUp(self):
         class CountedCallback:
-
             def __init__(self):
                 self.lock = threading.Lock()
                 self.n_called = 0
@@ -28,4 +26,9 @@ class CoilTimerTestCase(unittest.TestCase):
         timer.schedule(period, counter)
         with timer:
             time.sleep(period * factor)
-        self.assertAlmostEqual(counter.n_called, factor, delta=factor * 0.5, msg='Should provide 50% accuracy')
+        self.assertAlmostEqual(
+            counter.n_called,
+            factor,
+            delta=factor * 0.5,
+            msg="Should provide 50% accuracy",
+        )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
-import unittest
-import time
 import threading
+import time
+import unittest
 
 from coilmq.util.concurrency import CoilThreadingTimer
 


### PR DESCRIPTION
- add `[tool.ruff]` section to `pyproject.toml`
  - ruff is mostly left with its default configuration
  - rules related to calling `datetime` functions without passing `tzinfo` are disabled since coilmq does't care about timezones (coilmq doesn't send datetime objects/timestamps out to anyone, nor does it attempt to process a datetime object/timestamp sent from someone else); I plan to recommend switching to a monotonic timer for time measurements anyway
- run `ruff check --fix`
- run `ruff format`

Fixes #58 