### PR TITLE
46 update changelog before next release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,22 +21,22 @@ Unreleased
 * Use ``importlib.resources`` to load the default configuration
   (issue 56)
 
-1.0.1
------
+v1.0.1
+------
 
-1.0.0
------
+v1.0.0
+------
 
-0.6.1
------
+v0.6.1
+------
 * Error with one subscriber causes topic messages not to be delivered to 
   other subscribers (issue 33).
 * Fixed error in some circumstances when clearing pending transaction 
   frames with commit/abort (issue 30).
 * Fixed incorrect default address in help (issue 29).
 
-0.6.0
------
+v0.6.0
+------
 * Added a new diagnostic thread that will run when --debug option
   is passed on the commandline.
 * Added method to QueueManager API  to support tracking subscriber count. 
@@ -44,31 +44,30 @@ Unreleased
 * Fixed bug in engine.commit() and updated tests to catch previous 
   failure (issue 28).
 
-0.5.0
------
+v0.5.0
+------
 * Added support for RECEIPT header and server messages (issue 26). 
 
-0.4.4
------
-
+v0.4.4
+------
 * Fixed packaging (MANIFEST.in) to include defaults.cfg and config.cfg-sample
   (issue 23).
 * Fixed socket recv loop to appropriately handle client DISCONNECT messages
   (issue 24).
 
-0.4.3
------
+v0.4.3
+------
 * Fixed bug in requeuing of pending frames when client is disconnected
   (issue 22).
 * Fixed bug in unit test for dbm on windows (issue 21).
 
-0.4.2
------
+v0.4.2
+------
 * Added allow_socket_reuse (SO_REUSEADDR) option to SocketServer subclass
   to avoid having to wait to restart server after unclean client 
   disconnect. 
 
-0.4.1
------
+v0.4.1
+------
 * Added a changelog ;)
 * Added socket timeouts so that the server can be interrupted (e.g. CTRL-C)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,22 +4,28 @@
 
 Unreleased
 ----------
-* Removed uses of `pkg_resources` (issue 39)
-* Removed support for Python 2.7 through Python 3.7 (MR 37)
-* Fixed a defect in `coilmq.util.frames.FrameBuffer.extract_frame`: on
-  an `IncompleteFrame` error, this method set the buffer's next write
-  index to the read index (rather than the end of the buffer) causing
-  the subsequent `FrameBuffer.append()` call(s) to overwrite the
-  beginning of the frame and hanging the server (issue 44)
-* Fixed defects in CoilMQ's heart-beating implementation (issue 26)
-  * stop heart-beating threads when a connection closes
-  * treat any incoming traffic as a heart-beat
-  * tolerate heart-beats arriving as late as twice the requested interval
-* ``QueuePriorityScheduler`` is now a subclasses of ``abc.ABC``;
-  ``QueuePriorityScheduler.choice()`` is now an ``abc.abstractmethod``
-  (issue 53)
-* Use ``importlib.resources`` to load the default configuration
-  (issue 56)
+
+**Changed**
+
+- dropped support for Python 2.7 through Python 3.7 (:pr:`37`)
+- refactor tests to idiomatic pytest style (:pr:`66`)
+- use Sphinx markup for documentation (:pr:`52`)
+- format project code with ruff (:issue:`58`)
+
+**Fixed**
+
+- CoilMQ rejects CONNECT without accept-version header (:issue:`29`)
+- subscription id not returned to client (:issue:`25`)
+- error in ACK processing in version 1.1 protocol (:issue:`34`)
+- STOMP commands and header names should be case sensitive (:issue:`23`)
+- remove ``pkg_resources`` dependency (:issue:`39`)
+- CI builds are no longer running (:issue:`31`)
+- command line argument parsing with click 8 (:pr:`28`)
+- large messages corrupt `~coilmq.util.frames.FrameBuffer` and hang server (:issue:`44`)
+- heart-beat mechanism makes CoilMQ unusable with heartbeats enabled (:issue:`26`)
+- `~coilmq.scheduler.QueuePriorityScheduler` should be an abstract base class (:issue:`53`)
+- use `importlib.resources` to load the default configuration (:issue:`56`)
+- pytest treats ``TestStompServer`` and ``TestStompClient`` as test cases (:issue:`62`)
 
 v1.0.1
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,7 @@ v0.6.1
 v0.6.0
 ------
 * Added a new diagnostic thread that will run when --debug option
-  is passed on the commandline.
+  is passed on the command line.
 * Added method to QueueManager API  to support tracking subscriber count.
 * Improved unit and functional test coverage of storage engines.
 * Fixed bug in engine.commit() and updated tests to catch previous

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,9 +29,9 @@ v1.0.0
 
 v0.6.1
 ------
-* Error with one subscriber causes topic messages not to be delivered to 
+* Error with one subscriber causes topic messages not to be delivered to
   other subscribers (issue 33).
-* Fixed error in some circumstances when clearing pending transaction 
+* Fixed error in some circumstances when clearing pending transaction
   frames with commit/abort (issue 30).
 * Fixed incorrect default address in help (issue 29).
 
@@ -39,14 +39,14 @@ v0.6.0
 ------
 * Added a new diagnostic thread that will run when --debug option
   is passed on the commandline.
-* Added method to QueueManager API  to support tracking subscriber count. 
+* Added method to QueueManager API  to support tracking subscriber count.
 * Improved unit and functional test coverage of storage engines.
-* Fixed bug in engine.commit() and updated tests to catch previous 
+* Fixed bug in engine.commit() and updated tests to catch previous
   failure (issue 28).
 
 v0.5.0
 ------
-* Added support for RECEIPT header and server messages (issue 26). 
+* Added support for RECEIPT header and server messages (issue 26).
 
 v0.4.4
 ------
@@ -64,8 +64,8 @@ v0.4.3
 v0.4.2
 ------
 * Added allow_socket_reuse (SO_REUSEADDR) option to SocketServer subclass
-  to avoid having to wait to restart server after unclean client 
-  disconnect. 
+  to avoid having to wait to restart server after unclean client
+  disconnect.
 
 v0.4.1
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
  Changelog
 ===========
 
+..
+    Unreleased
+    ----------
+    **Added**
+    **Changed**
+    **Deprecated**
+    **Removed**
+    **Fixed**
+    **Security**
+
 Unreleased
 ----------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,24 @@ v1.0.1
 v1.0.0
 ------
 
+CoilMQ moved from Google Code to GitHub during the development of v1.0.0.  This section
+(and those above) refers to issues and PRs opened against CoilMQ on GitHub.  Sections
+for older releases (below) refer to issues opened against the `project on Google Code`_.
+
+.. _project on Google Code: https://code.google.com/archive/p/coilmq/issues
+
+**Added**
+
+- Python 3 support (:pr:`3`)
+- STOMP 1.1 support (:pr:`12`)
+- STOMP 1.2 support (:pr:`13`)
+- support for ``STOMP`` command (:pr:`14`)
+- `QueueStore` implementation backed by a Redis database (:pr:`15`)
+
+**Fixed**
+
+- show correct exception on TCPServer init error (:pr:`1`)
+
 v0.6.1
 ------
 * Error with one subscriber causes topic messages not to be delivered to

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,11 @@ Unreleased
 v1.0.1
 ------
 
+**Fixed**
+
+- ImportError: No module named 'pwd' (:issue:`20`)
+- replace `NotImplemented` with `NotImplementedError` (:pr:`18`)
+
 v1.0.0
 ------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
+    "sphinx_issues",
     "sphinx_paramlinks",
 ]
 
@@ -51,3 +52,8 @@ autosectionlabel_prefix_document = True
 # https://pypi.org/project/sphinx-paramlinks/#configuration
 
 paramlinks_hyperlink_param = "name"
+
+# -- Options for sphinx-issues extension -------------------------------------
+# https://github.com/sloria/sphinx-issues
+
+issues_github_path = "hozn/coilmq"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,7 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+import importlib.metadata
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -9,6 +10,8 @@
 project = "coilmq"
 copyright = "2009 - 2026, Hans Lellelid"
 author = "Hans Lellelid"
+
+version = release = importlib.metadata.version("coilmq")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,9 @@ extensions = [
     "sphinx_paramlinks",
 ]
 
+primary_domain = "py"
+default_role = "py:obj"
+
 exclude_patterns = [
     ".DS_Store",
     ".gitignoreThumbs.db",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs = [
     "furo>=2025.12.19",
     "sphinx>=9.1.0",
     "sphinx-autodoc-typehints>=3.9.11",
+    "sphinx-issues>=6.0.0",
     "sphinx-paramlinks>=0.6.0",
 ]
 tests = [

--- a/uv.lock
+++ b/uv.lock
@@ -279,6 +279,7 @@ docs = [
     { name = "furo", marker = "python_full_version >= '3.13'" },
     { name = "sphinx", marker = "python_full_version >= '3.13'" },
     { name = "sphinx-autodoc-typehints", marker = "python_full_version >= '3.13'" },
+    { name = "sphinx-issues", marker = "python_full_version >= '3.13'" },
     { name = "sphinx-paramlinks", marker = "python_full_version >= '3.13'" },
 ]
 tests = [
@@ -318,6 +319,7 @@ docs = [
     { name = "furo", marker = "python_full_version >= '3.13'", specifier = ">=2025.12.19" },
     { name = "sphinx", marker = "python_full_version >= '3.13'", specifier = ">=9.1.0" },
     { name = "sphinx-autodoc-typehints", marker = "python_full_version >= '3.13'", specifier = ">=3.9.11" },
+    { name = "sphinx-issues", marker = "python_full_version >= '3.13'", specifier = ">=6.0.0" },
     { name = "sphinx-paramlinks", marker = "python_full_version >= '3.13'", specifier = ">=0.6.0" },
 ]
 tests = [
@@ -1413,6 +1415,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinx-issues"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/4e/c9a46b19c90d4d3cdcbcaf0e4d392b09e5b41ec75b134bc5a1aa192be94f/sphinx_issues-6.0.0.tar.gz", hash = "sha256:f40f2c71cecb2068c7f06a53825778b674d58d8395b4ea60551a36164d2988e3", size = 15230, upload-time = "2026-03-13T17:23:32.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/8a/28333d222ac31539aa0d818db0790077e5a6a408f933b4bf64f7d3440ffc/sphinx_issues-6.0.0-py3-none-any.whl", hash = "sha256:c7ed2915059526d02022733985a7712d4b2b64a707e16b98294ed9758e64df4f", size = 8362, upload-time = "2026-03-13T17:23:31.031Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #46 

- Document changes in previously-absent 1.0.0 and 1.0.1
- Catch up the change list for the in-development version